### PR TITLE
Hide empty validation summary and surface server errors on edit pages

### DIFF
--- a/WebReckrytingSystem/Pages/Account/EditResume.cshtml
+++ b/WebReckrytingSystem/Pages/Account/EditResume.cshtml
@@ -18,7 +18,7 @@
     <div class="row justify-content-center">
         <div class="col-lg-10">
             <form method="post" id="resumeForm" novalidate>
-                <div asp-validation-summary="All" class="alert alert-danger rounded-pill"></div>
+                <div asp-validation-summary="All" class="alert alert-danger rounded-pill @(ViewData.ModelState.ErrorCount > 0 ? "" : "d-none")"></div>
 
                 <!-- Основная информация (2 колонки) -->
                 <div class="row g-4">

--- a/WebReckrytingSystem/Pages/Account/EditResume.cshtml.cs
+++ b/WebReckrytingSystem/Pages/Account/EditResume.cshtml.cs
@@ -71,14 +71,14 @@ namespace WebReckrytingSystem.Pages.Account
             var userEmail = User.FindFirst(ClaimTypes.Email)?.Value;
             if (string.IsNullOrWhiteSpace(userEmail))
             {
-                ErrorMessage = "Ошибка аутентификации";
+                ModelState.AddModelError(string.Empty, "Ошибка аутентификации");
                 return Page();
             }
 
             var result = _resumeService.UpdateResume(userEmail, ResumeData);
             if (!result.IsSuccess)
             {
-                ErrorMessage = result.Message;
+                ModelState.AddModelError(string.Empty, result.Message ?? "Не удалось обновить резюме");
                 return Page();
             }
 

--- a/WebReckrytingSystem/Pages/Company/Settings.cshtml
+++ b/WebReckrytingSystem/Pages/Company/Settings.cshtml
@@ -51,7 +51,7 @@
                     }
 
                     <form method="post" enctype="multipart/form-data">
-                        <div asp-validation-summary="All" class="alert alert-danger rounded-pill"></div>
+                        <div asp-validation-summary="All" class="alert alert-danger rounded-pill @(ViewData.ModelState.ErrorCount > 0 ? "" : "d-none")"></div>
 
                         <!-- Название компании -->
                         <div class="mb-4">

--- a/WebReckrytingSystem/Pages/Vacancy/Edit.cshtml
+++ b/WebReckrytingSystem/Pages/Vacancy/Edit.cshtml
@@ -13,7 +13,7 @@
                 </div>
                 <div class="card-body p-4">
                     <form method="post" id="editForm" novalidate>
-                        <div asp-validation-summary="All" class="alert alert-danger rounded-pill"></div>
+                        <div asp-validation-summary="All" class="alert alert-danger rounded-pill @(ViewData.ModelState.ErrorCount > 0 ? "" : "d-none")"></div>
 
                         <datalist id="companySuggestions">
                             @foreach (var company in Model.CompanySuggestions)

--- a/WebReckrytingSystem/Pages/Vacancy/Edit.cshtml.cs
+++ b/WebReckrytingSystem/Pages/Vacancy/Edit.cshtml.cs
@@ -110,7 +110,7 @@ namespace WebReckrytingSystem.Pages.Vacancy
             var userEmail = User.FindFirst(ClaimTypes.Email)?.Value;
             if (string.IsNullOrEmpty(userEmail))
             {
-                ErrorMessage = "Ошибка авторизации";
+                ModelState.AddModelError(string.Empty, "Ошибка авторизации");
                 _logger.LogWarning("No email claim while updating vacancy");
                 CurrentVacancy = _vacancyService.GetVacancy(companyName, title) ?? new Models.Vacancy();
                 return Page();
@@ -125,14 +125,14 @@ namespace WebReckrytingSystem.Pages.Vacancy
                     return RedirectToPage("/Account/EmployerDashboard");
                 }
 
-                ErrorMessage = result.Message;
+                ModelState.AddModelError(string.Empty, result.Message ?? "Не удалось обновить вакансию");
                 CurrentVacancy = _vacancyService.GetVacancy(companyName, title) ?? new Models.Vacancy();
                 return Page();
             }
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Unexpected error while updating vacancy");
-                ErrorMessage = "Произошла ошибка при обновлении вакансии";
+                ModelState.AddModelError(string.Empty, "Произошла ошибка при обновлении вакансии");
                 CurrentVacancy = _vacancyService.GetVacancy(companyName, title) ?? new Models.Vacancy();
                 return Page();
             }


### PR DESCRIPTION
### Motivation
- Prevent an empty red validation banner from showing immediately on edit pages (Resume, Company settings, Vacancy) when there are no errors. 
- Ensure server-side failures during update operations are surfaced to the user via the validation summary instead of an empty alert.

### Description
- Hide the `asp-validation-summary` alert by default in three Razor pages so it is only visible when `ModelState` contains errors (`@(ViewData.ModelState.ErrorCount > 0 ? "" : "d-none")`) in `Account/EditResume.cshtml`, `Company/Settings.cshtml`, and `Vacancy/Edit.cshtml`.
- Replace direct `ErrorMessage` assignments with `ModelState.AddModelError(...)` in `Account/EditResume.cshtml.cs` and `Pages/Vacancy/Edit.cshtml.cs` so update/authentication/service errors are shown in the validation summary.
- Minor content encoding normalization for `Vacancy/Edit.cshtml` to avoid BOM-related artifacts.

### Testing
- Attempted to run `dotnet build WebReckrytingSystem/WebReckrytingSystem.csproj`, but the `dotnet` SDK is not available in this environment, so the build could not be executed (failed).
- Attempted an automated browser check via Playwright (`page.goto('http://127.0.0.1:5000')`), but there was no running application server in the container and navigation returned `ERR_EMPTY_RESPONSE` (failed).
- No other automated tests were available or executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a813123b1c8333b364bb35c9089cf4)