### PR TITLE
Add dark theme, improve validation error display, and refine navbar/search UI and styles

### DIFF
--- a/WebReckrytingSystem/Pages/Account/EditResume.cshtml
+++ b/WebReckrytingSystem/Pages/Account/EditResume.cshtml
@@ -18,7 +18,7 @@
     <div class="row justify-content-center">
         <div class="col-lg-10">
             <form method="post" id="resumeForm" novalidate>
-                <div asp-validation-summary="All" class="alert alert-danger rounded-pill"></div>
+                <div asp-validation-summary="All" class="alert alert-danger rounded-pill @(ViewData.ModelState.ErrorCount > 0 ? "" : "d-none")"></div>
 
                 <!-- Основная информация (2 колонки) -->
                 <div class="row g-4">

--- a/WebReckrytingSystem/Pages/Account/EditResume.cshtml.cs
+++ b/WebReckrytingSystem/Pages/Account/EditResume.cshtml.cs
@@ -71,14 +71,14 @@ namespace WebReckrytingSystem.Pages.Account
             var userEmail = User.FindFirst(ClaimTypes.Email)?.Value;
             if (string.IsNullOrWhiteSpace(userEmail))
             {
-                ErrorMessage = "Ошибка аутентификации";
+                ModelState.AddModelError(string.Empty, "Ошибка аутентификации");
                 return Page();
             }
 
             var result = _resumeService.UpdateResume(userEmail, ResumeData);
             if (!result.IsSuccess)
             {
-                ErrorMessage = result.Message;
+                ModelState.AddModelError(string.Empty, result.Message ?? "Не удалось обновить резюме");
                 return Page();
             }
 

--- a/WebReckrytingSystem/Pages/Account/Settings.cshtml
+++ b/WebReckrytingSystem/Pages/Account/Settings.cshtml
@@ -28,6 +28,19 @@
                         </div>
                     }
 
+
+                    <div class="border rounded-3 p-3 mb-4">
+                        <div class="d-flex justify-content-between align-items-center">
+                            <div>
+                                <div class="fw-semibold">Тёмная тема</div>
+                                <small class="text-muted">Включить чёрную тему интерфейса</small>
+                            </div>
+                            <div class="form-check form-switch m-0">
+                                <input class="form-check-input" type="checkbox" id="themeToggle" role="switch" aria-label="Переключить тёмную тему">
+                            </div>
+                        </div>
+                    </div>
+
                     <form method="post">
                         <div asp-validation-summary="ModelOnly" class="text-danger"></div>
 
@@ -60,6 +73,25 @@
     </div>
 </div>
 
+
 @section Scripts {
     <partial name="_ValidationScriptsPartial" />
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            const themeToggle = document.getElementById('themeToggle');
+            if (!themeToggle) {
+                return;
+            }
+
+            const currentTheme = localStorage.getItem('theme') || 'light';
+            document.documentElement.setAttribute('data-theme', currentTheme);
+            themeToggle.checked = currentTheme === 'dark';
+
+            themeToggle.addEventListener('change', () => {
+                const nextTheme = themeToggle.checked ? 'dark' : 'light';
+                document.documentElement.setAttribute('data-theme', nextTheme);
+                localStorage.setItem('theme', nextTheme);
+            });
+        });
+    </script>
 }

--- a/WebReckrytingSystem/Pages/Company/Settings.cshtml
+++ b/WebReckrytingSystem/Pages/Company/Settings.cshtml
@@ -51,7 +51,7 @@
                     }
 
                     <form method="post" enctype="multipart/form-data">
-                        <div asp-validation-summary="All" class="alert alert-danger rounded-pill"></div>
+                        <div asp-validation-summary="All" class="alert alert-danger rounded-pill @(ViewData.ModelState.ErrorCount > 0 ? "" : "d-none")"></div>
 
                         <!-- Название компании -->
                         <div class="mb-4">

--- a/WebReckrytingSystem/Pages/Shared/_Layout.cshtml
+++ b/WebReckrytingSystem/Pages/Shared/_Layout.cshtml
@@ -41,8 +41,6 @@
                     ? "resumes"
                     : "vacancies";
         var searchUrl = isEmployer ? "/Resume/Search" : "/Vacancy/Search";
-        var searchPlaceholder = isEmployer ? "Найти резюме по навыкам или должности" : "Найти вакансию по ключевым словам";
-
         var showNavbarSearch = currentPage == "/Vacancy/Search" || currentPage == "/Resume/Search";
     }
 
@@ -75,15 +73,6 @@
                                         <button type="button" class="search-mode-btn @(defaultSearchMode == "vacancies" ? "active" : "")" data-search-mode="vacancies">Вакансии</button>
                                         <button type="button" class="search-mode-btn @(defaultSearchMode == "resumes" ? "active" : "")" data-search-mode="resumes">Резюме</button>
                                     </div>
-                                    <form id="navbarSearchForm" method="get" action="@searchUrl" class="navbar-search-form">
-                                        <input id="navbarSearchInput"
-                                               type="text"
-                                               class="form-control"
-                                               name="Keywords"
-                                               placeholder="@searchPlaceholder"
-                                               autocomplete="off" />
-                                        <button type="submit" class="btn btn-login">Поиск</button>
-                                    </form>
                                 </div>
                             }
 
@@ -188,21 +177,11 @@
     <script>
         document.addEventListener('DOMContentLoaded', () => {
             const switchButtons = document.querySelectorAll('.search-mode-btn');
-            const searchForm = document.getElementById('navbarSearchForm');
-            const searchInput = document.getElementById('navbarSearchInput');
-
-            if (!switchButtons.length || !searchForm || !searchInput) {
+            if (!switchButtons.length) {
                 return;
             }
 
             const applySearchMode = (mode) => {
-                const isResumeMode = mode === 'resumes';
-                searchForm.action = isResumeMode ? '/Resume/Search' : '/Vacancy/Search';
-                searchInput.name = isResumeMode ? 'SearchQuery' : 'Keywords';
-                searchInput.placeholder = isResumeMode
-                    ? 'Найти резюме по навыкам или должности'
-                    : 'Найти вакансию по ключевым словам';
-
                 switchButtons.forEach((button) => {
                     button.classList.toggle('active', button.dataset.searchMode === mode);
                 });

--- a/WebReckrytingSystem/Pages/Vacancy/Edit.cshtml
+++ b/WebReckrytingSystem/Pages/Vacancy/Edit.cshtml
@@ -13,7 +13,7 @@
                 </div>
                 <div class="card-body p-4">
                     <form method="post" id="editForm" novalidate>
-                        <div asp-validation-summary="All" class="alert alert-danger rounded-pill"></div>
+                        <div asp-validation-summary="All" class="alert alert-danger rounded-pill @(ViewData.ModelState.ErrorCount > 0 ? "" : "d-none")"></div>
 
                         <datalist id="companySuggestions">
                             @foreach (var company in Model.CompanySuggestions)

--- a/WebReckrytingSystem/Pages/Vacancy/Edit.cshtml.cs
+++ b/WebReckrytingSystem/Pages/Vacancy/Edit.cshtml.cs
@@ -110,7 +110,7 @@ namespace WebReckrytingSystem.Pages.Vacancy
             var userEmail = User.FindFirst(ClaimTypes.Email)?.Value;
             if (string.IsNullOrEmpty(userEmail))
             {
-                ErrorMessage = "Ошибка авторизации";
+                ModelState.AddModelError(string.Empty, "Ошибка авторизации");
                 _logger.LogWarning("No email claim while updating vacancy");
                 CurrentVacancy = _vacancyService.GetVacancy(companyName, title) ?? new Models.Vacancy();
                 return Page();
@@ -125,14 +125,14 @@ namespace WebReckrytingSystem.Pages.Vacancy
                     return RedirectToPage("/Account/EmployerDashboard");
                 }
 
-                ErrorMessage = result.Message;
+                ModelState.AddModelError(string.Empty, result.Message ?? "Не удалось обновить вакансию");
                 CurrentVacancy = _vacancyService.GetVacancy(companyName, title) ?? new Models.Vacancy();
                 return Page();
             }
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Unexpected error while updating vacancy");
-                ErrorMessage = "Произошла ошибка при обновлении вакансии";
+                ModelState.AddModelError(string.Empty, "Произошла ошибка при обновлении вакансии");
                 CurrentVacancy = _vacancyService.GetVacancy(companyName, title) ?? new Models.Vacancy();
                 return Page();
             }

--- a/WebReckrytingSystem/wwwroot/css/careerflow.css
+++ b/WebReckrytingSystem/wwwroot/css/careerflow.css
@@ -95,18 +95,18 @@ img,
 
 .search-mode-switcher {
     display: inline-flex;
-    gap: 0.4rem;
-    margin-bottom: 0.35rem;
+    gap: 0.5rem;
 }
 
 .search-mode-btn {
     border: 1px solid #dbe1f0;
     background: #f6f8ff;
     color: var(--text-dark);
-    padding: 0.2rem 0.8rem;
+    padding: 0.45rem 1.1rem;
     border-radius: 999px;
-    font-size: 0.8rem;
+    font-size: 0.95rem;
     font-weight: 600;
+    line-height: 1.2;
 }
 
 .search-mode-btn.active {
@@ -586,4 +586,42 @@ img,
         position: static;
         width: 100%;
     }
+}
+
+/* ===== DARK THEME ===== */
+:root[data-theme='dark'] body {
+    background-color: #0f1115;
+    color: #e9edf5;
+}
+
+:root[data-theme='dark'] .navbar.fixed-top {
+    background: rgba(18, 21, 28, 0.95) !important;
+}
+
+:root[data-theme='dark'] .card,
+:root[data-theme='dark'] .dropdown-menu {
+    background-color: #1a1f29;
+    color: #e9edf5;
+}
+
+:root[data-theme='dark'] .card-header,
+:root[data-theme='dark'] .card-footer {
+    border-color: #2d3442;
+}
+
+:root[data-theme='dark'] .form-control,
+:root[data-theme='dark'] .form-select {
+    background-color: #11161f;
+    color: #e9edf5;
+    border-color: #364054;
+}
+
+:root[data-theme='dark'] .form-control:focus,
+:root[data-theme='dark'] .form-select:focus {
+    background-color: #11161f;
+    color: #ffffff;
+}
+
+:root[data-theme='dark'] .text-muted {
+    color: #aab3c5 !important;
 }

--- a/WebReckrytingSystem/wwwroot/js/modern.js
+++ b/WebReckrytingSystem/wwwroot/js/modern.js
@@ -53,17 +53,6 @@
         setBubble();
     });
 
-    // переключатель темы (если нужно)
-    const toggle = document.createElement('button');
-    toggle.className = 'btn btn-sm btn-outline-secondary position-fixed top-0 end-0 m-3';
-    toggle.innerHTML = '🌓';
-    toggle.onclick = () => {
-        const html = document.documentElement;
-        const current = html.getAttribute('data-theme');
-        const next = current === 'dark' ? 'light' : 'dark';   
-        html.setAttribute('data-theme', next);
-        localStorage.setItem('theme', next);
-    };
-    document.body.appendChild(toggle);
+    // применяем сохранённую тему
     document.documentElement.setAttribute('data-theme', localStorage.getItem('theme') || 'light');
 })(); 


### PR DESCRIPTION
### Motivation
- Provide a persistent dark theme and a settings toggle so users can switch UI theme and keep preference across sessions.
- Surface server-side errors directly in model validation so validation messages display next to form elements and the summary behaves consistently.
- Simplify and harden navbar search mode switching and adjust search-mode button styles for better responsiveness and layout.

### Description
- Added a theme switch UI to `Pages/Account/Settings.cshtml` and a script to persist/apply theme using `localStorage` and `data-theme` attributes.
- Introduced dark-theme CSS rules in `wwwroot/css/careerflow.css` and adjusted `.search-mode-btn` sizing/gap for improved visuals.
- Reworked theme initialization in `wwwroot/js/modern.js` to apply saved theme on load and removed the appended toggle button.
- Changed validation summary containers in several Razor pages (`EditResume.cshtml`, `Company/Settings.cshtml`, `Vacancy/Edit.cshtml`) to hide when there are no model errors by adding conditional `d-none` based on `ViewData.ModelState.ErrorCount`.
- Replaced usages of page-level `ErrorMessage` with `ModelState.AddModelError(string.Empty, ...)` in `EditResume.cshtml.cs` and `Vacancy/Edit.cshtml.cs` so server errors are shown in the validation summary.
- Simplified `_Layout.cshtml` by removing the inline navbar search input/placeholder wiring and updated the client-side search-mode script to only control mode buttons and navigate to the appropriate search page.

### Testing
- Executed `dotnet build` for the solution and the build completed successfully.
- Executed `dotnet test` and all discovered automated tests passed without failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a813123b1c8333b364bb35c9089cf4)