### PR TITLE
Handle missing `saved_resumes` table when saving/loading resume favorites

### DIFF
--- a/WebReckrytingSystem/Pages/Account/Favorites.cshtml.cs
+++ b/WebReckrytingSystem/Pages/Account/Favorites.cshtml.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.EntityFrameworkCore;
+using MySqlConnector;
 using System.Security.Claims;
 using WebReckrytingSystem.Models;
 
@@ -32,20 +33,51 @@ namespace WebReckrytingSystem.Pages.Account
             {
                 SavedVacancies = await _context.SavedVacancies
                     .Where(s => s.StudentEmail == userEmail)
-                    .Include(s => s.Vacancy) // потребуется навигационное свойство
+                    .Include(s => s.Vacancy)
                     .OrderByDescending(s => s.SavedAt)
                     .ToListAsync();
             }
             else if (role == "employer")
             {
-                SavedResumes = await _context.SavedResumes
-                    .Where(s => s.EmployerEmail == userEmail)
-                    .Include(s => s.Resume) // тоже нужно навигационное свойство
-                    .OrderByDescending(s => s.SavedAt)
-                    .ToListAsync();
+                try
+                {
+                    SavedResumes = await _context.SavedResumes
+                        .Where(s => s.EmployerEmail == userEmail)
+                        .Include(s => s.Resume)
+                        .OrderByDescending(s => s.SavedAt)
+                        .ToListAsync();
+                }
+                catch (MySqlException ex) when (IsSavedResumesTableMissing(ex))
+                {
+                    await EnsureSavedResumesTableExistsAsync();
+                    SavedResumes = new List<SavedResume>();
+                }
             }
 
             return Page();
+        }
+
+        private static bool IsSavedResumesTableMissing(MySqlException ex)
+        {
+            return ex.Message.Contains("saved_resumes", StringComparison.OrdinalIgnoreCase)
+                   && ex.Message.Contains("doesn't exist", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private async Task EnsureSavedResumesTableExistsAsync()
+        {
+            const string sql = @"
+CREATE TABLE IF NOT EXISTS saved_resumes (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    employer_email VARCHAR(255) NOT NULL,
+    resume_user_email VARCHAR(255) NOT NULL,
+    saved_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE KEY uq_saved_resumes_unique (employer_email, resume_user_email),
+    INDEX idx_saved_resumes_employer_email (employer_email),
+    INDEX idx_saved_resumes_resume_user_email (resume_user_email),
+    CONSTRAINT fk_saved_resumes_resume FOREIGN KEY (resume_user_email) REFERENCES resumes(user_email) ON DELETE CASCADE
+);";
+
+            await _context.Database.ExecuteSqlRawAsync(sql);
         }
     }
 }

--- a/WebReckrytingSystem/Pages/Resume/Details.cshtml.cs
+++ b/WebReckrytingSystem/Pages/Resume/Details.cshtml.cs
@@ -54,8 +54,9 @@ namespace WebReckrytingSystem.Pages.Resume
                 }
                 catch (MySqlException ex) when (IsSavedResumesTableMissing(ex))
                 {
-                    IsSavedByCurrentEmployer = false;
-                    TempData["StatusMessage"] = "Функция избранного временно недоступна.";
+                    await EnsureSavedResumesTableExistsAsync();
+                    IsSavedByCurrentEmployer = await _context.SavedResumes
+                        .AnyAsync(s => s.EmployerEmail == currentUserEmail && s.ResumeUserEmail == userEmail);
                 }
 
                 HasExistingChat = await _context.ChatMessages
@@ -89,8 +90,10 @@ namespace WebReckrytingSystem.Pages.Resume
             }
             catch (MySqlException ex) when (IsSavedResumesTableMissing(ex))
             {
-                TempData["StatusMessage"] = "Функция избранного временно недоступна.";
-                return RedirectToPage(new { userEmail = resumeUserEmail });
+                await EnsureSavedResumesTableExistsAsync();
+
+                existing = await _context.SavedResumes
+                    .FirstOrDefaultAsync(s => s.EmployerEmail == employerEmail && s.ResumeUserEmail == resumeUserEmail);
             }
 
             if (existing == null)
@@ -114,7 +117,8 @@ namespace WebReckrytingSystem.Pages.Resume
             }
             catch (MySqlException ex) when (IsSavedResumesTableMissing(ex))
             {
-                TempData["StatusMessage"] = "Функция избранного временно недоступна.";
+                await EnsureSavedResumesTableExistsAsync();
+                await _context.SaveChangesAsync();
             }
 
             return RedirectToPage(new { userEmail = resumeUserEmail });
@@ -124,6 +128,23 @@ namespace WebReckrytingSystem.Pages.Resume
         {
             return ex.Message.Contains("saved_resumes", StringComparison.OrdinalIgnoreCase)
                    && ex.Message.Contains("doesn't exist", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private async Task EnsureSavedResumesTableExistsAsync()
+        {
+            const string sql = @"
+CREATE TABLE IF NOT EXISTS saved_resumes (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    employer_email VARCHAR(255) NOT NULL,
+    resume_user_email VARCHAR(255) NOT NULL,
+    saved_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE KEY uq_saved_resumes_unique (employer_email, resume_user_email),
+    INDEX idx_saved_resumes_employer_email (employer_email),
+    INDEX idx_saved_resumes_resume_user_email (resume_user_email),
+    CONSTRAINT fk_saved_resumes_resume FOREIGN KEY (resume_user_email) REFERENCES resumes(user_email) ON DELETE CASCADE
+);";
+
+            await _context.Database.ExecuteSqlRawAsync(sql);
         }
     }
 }


### PR DESCRIPTION
### Motivation
- Resume "save to favorites" feature failed for employers when the `saved_resumes` table was absent in some deployments, causing save/load operations to throw database errors. 
- The change aims to make the favorites flow resilient by creating the missing table on demand and retrying the operation so the UI remains usable.

### Description
- Added detection of the missing `saved_resumes` table by inspecting `MySqlException` in `Resume/Details` and `Account/Favorites` page models. 
- Introduced `EnsureSavedResumesTableExistsAsync()` that runs `CREATE TABLE IF NOT EXISTS saved_resumes (...)` with indexes and a foreign key to `resumes(user_email)`. 
- Wrapped queries that read/write `SavedResumes` in `try/catch` handlers to call the ensure method and retry the DB operation instead of failing or showing a temporary-unavailable message. 

### Testing
- Attempted to run unit tests with `dotnet test WebReckrytingSystem.Tests/WebReckrytingSystem.Tests.csproj`, but the `dotnet` runtime/SDK is not available in the current environment so tests could not be executed (failed to run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6d9aaed1c8333aad0387b48dc6bb2)