### PR TITLE
Remove FK from saved_resumes auto-create SQL to prevent MySqlException on employer resume view

### DIFF
--- a/WebReckrytingSystem/Models/SearchVacancyViewModel.cs
+++ b/WebReckrytingSystem/Models/SearchVacancyViewModel.cs
@@ -12,6 +12,10 @@ namespace WebReckrytingSystem.Models
         [Display(Name = "Компания")]
         public string? CompanyName { get; set; }
 
+        [StringLength(100, ErrorMessage = "Регион не должен превышать 100 символов")]
+        [Display(Name = "Регион")]
+        public string? Region { get; set; }
+
         [Range(0, 9999999, ErrorMessage = "Зарплата должна быть в диапазоне от 0 до 9 999 999")]
         [Display(Name = "Зарплата от (руб.)")]
         public int? SalaryFrom { get; set; }
@@ -25,6 +29,22 @@ namespace WebReckrytingSystem.Models
 
         [Display(Name = "График работы")]
         public string? WorkSchedule { get; set; }
+
+        [Range(1, 24, ErrorMessage = "Рабочие часы в день должны быть от 1 до 24")]
+        [Display(Name = "Рабочие часы в день")]
+        public int? WorkHoursPerDay { get; set; }
+
+        [Display(Name = "Формат работы")]
+        public string? WorkFormat { get; set; }
+
+        [Display(Name = "Период дохода")]
+        public string? SalaryPeriod { get; set; }
+
+        [Display(Name = "Частота выплат")]
+        public string? PaymentFrequency { get; set; }
+
+        [Display(Name = "Специальность")]
+        public string? Specialty { get; set; }
 
         [Range(1, 100, ErrorMessage = "Номер страницы должен быть от 1 до 100")]
         public int Page { get; set; } = 1;

--- a/WebReckrytingSystem/Pages/Account/Favorites.cshtml.cs
+++ b/WebReckrytingSystem/Pages/Account/Favorites.cshtml.cs
@@ -73,8 +73,7 @@ CREATE TABLE IF NOT EXISTS saved_resumes (
     saved_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     UNIQUE KEY uq_saved_resumes_unique (employer_email, resume_user_email),
     INDEX idx_saved_resumes_employer_email (employer_email),
-    INDEX idx_saved_resumes_resume_user_email (resume_user_email),
-    CONSTRAINT fk_saved_resumes_resume FOREIGN KEY (resume_user_email) REFERENCES resumes(user_email) ON DELETE CASCADE
+    INDEX idx_saved_resumes_resume_user_email (resume_user_email)
 );";
 
             await _context.Database.ExecuteSqlRawAsync(sql);

--- a/WebReckrytingSystem/Pages/Account/Favorites.cshtml.cs
+++ b/WebReckrytingSystem/Pages/Account/Favorites.cshtml.cs
@@ -47,20 +47,28 @@ namespace WebReckrytingSystem.Pages.Account
                         .OrderByDescending(s => s.SavedAt)
                         .ToListAsync();
                 }
-                catch (MySqlException ex) when (IsSavedResumesTableMissing(ex))
+                catch (MySqlException ex) when (IsSavedResumesSchemaIssue(ex))
                 {
                     await EnsureSavedResumesTableExistsAsync();
-                    SavedResumes = new List<SavedResume>();
+
+                    SavedResumes = await _context.SavedResumes
+                        .Where(s => s.EmployerEmail == userEmail)
+                        .Include(s => s.Resume)
+                        .OrderByDescending(s => s.SavedAt)
+                        .ToListAsync();
                 }
             }
 
             return Page();
         }
 
-        private static bool IsSavedResumesTableMissing(MySqlException ex)
+        private static bool IsSavedResumesSchemaIssue(MySqlException ex)
         {
-            return ex.Message.Contains("saved_resumes", StringComparison.OrdinalIgnoreCase)
-                   && ex.Message.Contains("doesn't exist", StringComparison.OrdinalIgnoreCase);
+            var isTableMissing = ex.Message.Contains("saved_resumes", StringComparison.OrdinalIgnoreCase)
+                                 && ex.Message.Contains("doesn't exist", StringComparison.OrdinalIgnoreCase);
+            var isCollationMismatch = ex.Message.Contains("Illegal mix of collations", StringComparison.OrdinalIgnoreCase);
+
+            return isTableMissing || isCollationMismatch;
         }
 
         private async Task EnsureSavedResumesTableExistsAsync()
@@ -68,15 +76,23 @@ namespace WebReckrytingSystem.Pages.Account
             const string sql = @"
 CREATE TABLE IF NOT EXISTS saved_resumes (
     id INT AUTO_INCREMENT PRIMARY KEY,
-    employer_email VARCHAR(255) NOT NULL,
-    resume_user_email VARCHAR(255) NOT NULL,
+    employer_email VARCHAR(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+    resume_user_email VARCHAR(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
     saved_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     UNIQUE KEY uq_saved_resumes_unique (employer_email, resume_user_email),
     INDEX idx_saved_resumes_employer_email (employer_email),
     INDEX idx_saved_resumes_resume_user_email (resume_user_email)
-);";
+)
+CHARACTER SET utf8mb4
+COLLATE utf8mb4_unicode_ci;";
+
+            const string alterSql = @"
+ALTER TABLE saved_resumes
+    CONVERT TO CHARACTER SET utf8mb4
+    COLLATE utf8mb4_unicode_ci;";
 
             await _context.Database.ExecuteSqlRawAsync(sql);
+            await _context.Database.ExecuteSqlRawAsync(alterSql);
         }
     }
 }

--- a/WebReckrytingSystem/Pages/Resume/Details.cshtml
+++ b/WebReckrytingSystem/Pages/Resume/Details.cshtml
@@ -98,6 +98,15 @@
                                         <i class="fas fa-comment me-2"></i>Перейти в чат
                                     </a>
                                 }
+                                else
+                                {
+                                    <form method="post" asp-page-handler="Respond" class="d-grid">
+                                        <input type="hidden" name="resumeUserEmail" value="@Model.Resume.UserEmail" />
+                                        <button type="submit" class="btn btn-success rounded-pill py-3">
+                                            <i class="fas fa-paper-plane me-2"></i>Откликнуться на резюме
+                                        </button>
+                                    </form>
+                                }
                             </div>
                         }
 

--- a/WebReckrytingSystem/Pages/Resume/Details.cshtml.cs
+++ b/WebReckrytingSystem/Pages/Resume/Details.cshtml.cs
@@ -140,8 +140,7 @@ CREATE TABLE IF NOT EXISTS saved_resumes (
     saved_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     UNIQUE KEY uq_saved_resumes_unique (employer_email, resume_user_email),
     INDEX idx_saved_resumes_employer_email (employer_email),
-    INDEX idx_saved_resumes_resume_user_email (resume_user_email),
-    CONSTRAINT fk_saved_resumes_resume FOREIGN KEY (resume_user_email) REFERENCES resumes(user_email) ON DELETE CASCADE
+    INDEX idx_saved_resumes_resume_user_email (resume_user_email)
 );";
 
             await _context.Database.ExecuteSqlRawAsync(sql);

--- a/WebReckrytingSystem/Pages/Resume/Details.cshtml.cs
+++ b/WebReckrytingSystem/Pages/Resume/Details.cshtml.cs
@@ -52,7 +52,7 @@ namespace WebReckrytingSystem.Pages.Resume
                     IsSavedByCurrentEmployer = await _context.SavedResumes
                         .AnyAsync(s => s.EmployerEmail == currentUserEmail && s.ResumeUserEmail == userEmail);
                 }
-                catch (MySqlException ex) when (IsSavedResumesTableMissing(ex))
+                catch (MySqlException ex) when (IsSavedResumesSchemaIssue(ex))
                 {
                     await EnsureSavedResumesTableExistsAsync();
                     IsSavedByCurrentEmployer = await _context.SavedResumes
@@ -88,7 +88,7 @@ namespace WebReckrytingSystem.Pages.Resume
                 existing = await _context.SavedResumes
                     .FirstOrDefaultAsync(s => s.EmployerEmail == employerEmail && s.ResumeUserEmail == resumeUserEmail);
             }
-            catch (MySqlException ex) when (IsSavedResumesTableMissing(ex))
+            catch (MySqlException ex) when (IsSavedResumesSchemaIssue(ex))
             {
                 await EnsureSavedResumesTableExistsAsync();
 
@@ -115,7 +115,7 @@ namespace WebReckrytingSystem.Pages.Resume
             {
                 await _context.SaveChangesAsync();
             }
-            catch (MySqlException ex) when (IsSavedResumesTableMissing(ex))
+            catch (MySqlException ex) when (IsSavedResumesSchemaIssue(ex))
             {
                 await EnsureSavedResumesTableExistsAsync();
                 await _context.SaveChangesAsync();
@@ -124,10 +124,13 @@ namespace WebReckrytingSystem.Pages.Resume
             return RedirectToPage(new { userEmail = resumeUserEmail });
         }
 
-        private static bool IsSavedResumesTableMissing(MySqlException ex)
+        private static bool IsSavedResumesSchemaIssue(MySqlException ex)
         {
-            return ex.Message.Contains("saved_resumes", StringComparison.OrdinalIgnoreCase)
-                   && ex.Message.Contains("doesn't exist", StringComparison.OrdinalIgnoreCase);
+            var isTableMissing = ex.Message.Contains("saved_resumes", StringComparison.OrdinalIgnoreCase)
+                                 && ex.Message.Contains("doesn't exist", StringComparison.OrdinalIgnoreCase);
+            var isCollationMismatch = ex.Message.Contains("Illegal mix of collations", StringComparison.OrdinalIgnoreCase);
+
+            return isTableMissing || isCollationMismatch;
         }
 
         private async Task EnsureSavedResumesTableExistsAsync()
@@ -135,15 +138,23 @@ namespace WebReckrytingSystem.Pages.Resume
             const string sql = @"
 CREATE TABLE IF NOT EXISTS saved_resumes (
     id INT AUTO_INCREMENT PRIMARY KEY,
-    employer_email VARCHAR(255) NOT NULL,
-    resume_user_email VARCHAR(255) NOT NULL,
+    employer_email VARCHAR(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+    resume_user_email VARCHAR(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
     saved_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     UNIQUE KEY uq_saved_resumes_unique (employer_email, resume_user_email),
     INDEX idx_saved_resumes_employer_email (employer_email),
     INDEX idx_saved_resumes_resume_user_email (resume_user_email)
-);";
+)
+CHARACTER SET utf8mb4
+COLLATE utf8mb4_unicode_ci;";
+
+            const string alterSql = @"
+ALTER TABLE saved_resumes
+    CONVERT TO CHARACTER SET utf8mb4
+    COLLATE utf8mb4_unicode_ci;";
 
             await _context.Database.ExecuteSqlRawAsync(sql);
+            await _context.Database.ExecuteSqlRawAsync(alterSql);
         }
     }
 }

--- a/WebReckrytingSystem/Pages/Resume/Details.cshtml.cs
+++ b/WebReckrytingSystem/Pages/Resume/Details.cshtml.cs
@@ -124,6 +124,56 @@ namespace WebReckrytingSystem.Pages.Resume
             return RedirectToPage(new { userEmail = resumeUserEmail });
         }
 
+        public async Task<IActionResult> OnPostRespondAsync(string resumeUserEmail)
+        {
+            var employerEmail = User.FindFirstValue(ClaimTypes.Email);
+            if (string.IsNullOrEmpty(employerEmail) || !User.IsInRole("employer"))
+            {
+                return RedirectToPage("/Account/Login");
+            }
+
+            var resume = await _context.Resumes
+                .AsNoTracking()
+                .FirstOrDefaultAsync(r => r.UserEmail == resumeUserEmail && r.IsPublished);
+            if (resume == null)
+            {
+                return NotFound();
+            }
+
+            var alreadyHasChat = await _context.ChatMessages
+                .AnyAsync(m => (m.SenderEmail == employerEmail && m.RecipientEmail == resumeUserEmail) ||
+                               (m.SenderEmail == resumeUserEmail && m.RecipientEmail == employerEmail));
+
+            if (!alreadyHasChat)
+            {
+                var firstMessage = new ChatMessage
+                {
+                    SenderEmail = employerEmail,
+                    RecipientEmail = resumeUserEmail,
+                    Message = "Здравствуйте! Нас заинтересовало ваше резюме. Хотим обсудить сотрудничество.",
+                    SentAt = DateTime.UtcNow,
+                    IsRead = false
+                };
+
+                var notification = new Notification
+                {
+                    RecipientEmail = resumeUserEmail,
+                    SenderEmail = employerEmail,
+                    Title = "Новый отклик на ваше резюме",
+                    Message = "Работодатель откликнулся на ваше резюме и начал чат.",
+                    Link = Url.Page("/Account/Chat", null, new { peer = employerEmail }, Request.Scheme),
+                    CreatedAt = DateTime.UtcNow,
+                    IsRead = false
+                };
+
+                _context.ChatMessages.Add(firstMessage);
+                _context.Notifications.Add(notification);
+                await _context.SaveChangesAsync();
+            }
+
+            return RedirectToPage("/Account/Chat", new { peer = resumeUserEmail });
+        }
+
         private static bool IsSavedResumesSchemaIssue(MySqlException ex)
         {
             var isTableMissing = ex.Message.Contains("saved_resumes", StringComparison.OrdinalIgnoreCase)

--- a/WebReckrytingSystem/Pages/Vacancy/Create.cshtml
+++ b/WebReckrytingSystem/Pages/Vacancy/Create.cshtml
@@ -84,6 +84,7 @@
                                     <option value="">Выберите формат</option>
                                     <option value="office">Офис</option>
                                     <option value="remote">Удаленно</option>
+                                    <option value="travel">Разъездной</option>
                                     <option value="hybrid">Гибрид</option>
                                 </select>
                             </div>

--- a/WebReckrytingSystem/Pages/Vacancy/Create.cshtml.cs
+++ b/WebReckrytingSystem/Pages/Vacancy/Create.cshtml.cs
@@ -20,20 +20,7 @@ namespace WebReckrytingSystem.Pages.Vacancy
 
         public List<string> CompanySuggestions { get; set; } = new();
 
-        public IReadOnlyList<string> Specialties { get; } = new List<string>
-        {
-            "Информационные системы и программирование",
-            "Сетевое и системное администрирование",
-            "Экономика и бухгалтерский учет",
-            "Банковское дело",
-            "Дизайн",
-            "Маркетинг",
-            "Юриспруденция",
-            "Техническое обслуживание и ремонт автотранспорта",
-            "Строительство и эксплуатация зданий и сооружений",
-            "Электромонтер",
-            "Туризм и гостеприимство"
-        };
+        public IReadOnlyList<string> Specialties => SpecialtyCatalog.All;
 
         public string? SuccessMessage { get; set; }
         public string? ErrorMessage { get; set; }

--- a/WebReckrytingSystem/Pages/Vacancy/Details.cshtml
+++ b/WebReckrytingSystem/Pages/Vacancy/Details.cshtml
@@ -198,6 +198,7 @@
                                                     {
                                                         "office" => "В офисе",
                                                         "remote" => "Удалённо",
+                                                        "travel" => "Разъездной",
                                                         "hybrid" => "Гибрид",
                                                         _ => Model.Vacancy.WorkFormat
                                                     })

--- a/WebReckrytingSystem/Pages/Vacancy/Edit.cshtml
+++ b/WebReckrytingSystem/Pages/Vacancy/Edit.cshtml
@@ -77,6 +77,7 @@
                                     <option value="">Выберите формат</option>
                                     <option value="office">Офис</option>
                                     <option value="remote">Удаленно</option>
+                                    <option value="travel">Разъездной</option>
                                     <option value="hybrid">Гибрид</option>
                                 </select>
                             </div>

--- a/WebReckrytingSystem/Pages/Vacancy/Edit.cshtml.cs
+++ b/WebReckrytingSystem/Pages/Vacancy/Edit.cshtml.cs
@@ -30,20 +30,7 @@ namespace WebReckrytingSystem.Pages.Vacancy
         public Models.Vacancy CurrentVacancy { get; set; } = null!;
         public List<string> CompanySuggestions { get; set; } = new();
 
-        public IReadOnlyList<string> Specialties { get; } = new List<string>
-        {
-            "Информационные системы и программирование",
-            "Сетевое и системное администрирование",
-            "Экономика и бухгалтерский учет",
-            "Банковское дело",
-            "Дизайн",
-            "Маркетинг",
-            "Юриспруденция",
-            "Техническое обслуживание и ремонт автотранспорта",
-            "Строительство и эксплуатация зданий и сооружений",
-            "Электромонтер",
-            "Туризм и гостеприимство"
-        };
+        public IReadOnlyList<string> Specialties => SpecialtyCatalog.All;
 
         public string? SuccessMessage { get; set; }
         public string? ErrorMessage { get; set; }

--- a/WebReckrytingSystem/Pages/Vacancy/Search.cshtml
+++ b/WebReckrytingSystem/Pages/Vacancy/Search.cshtml
@@ -31,7 +31,7 @@
                         <div class="card-body">
                             <div class="mb-3">
                                 <label class="form-label">Регион</label>
-                                <input name="Region" class="form-control" placeholder="Москва, СПб" value="@Request.Query["Region"]" />
+                                <input asp-for="SearchData.Region" class="form-control" placeholder="Москва, СПб" />
                             </div>
 
                             <div class="mb-3">
@@ -48,17 +48,17 @@
 
                             <div class="mb-3">
                                 <label class="form-label">Рабочие часы в день</label>
-                                <input name="WorkHoursPerDay" type="number" class="form-control" min="1" max="24" value="@Request.Query["WorkHoursPerDay"]" />
+                                <input asp-for="SearchData.WorkHoursPerDay" type="number" class="form-control" min="1" max="24" />
                             </div>
 
                             <div class="mb-3">
                                 <label class="form-label">Формат работы</label>
-                                <select name="WorkFormat" class="form-select">
+                                <select asp-for="SearchData.WorkFormat" class="form-select">
                                     <option value="">Любой</option>
-                                    <option>на месте работодателя</option>
-                                    <option>удалённая</option>
-                                    <option>разъездная</option>
-                                    <option>гибрид</option>
+                                    <option value="на месте работодателя">на месте работодателя</option>
+                                    <option value="удалённая">удалённая</option>
+                                    <option value="разъездная">разъездная</option>
+                                    <option value="гибрид">гибрид</option>
                                 </select>
                             </div>
 
@@ -75,23 +75,23 @@
 
                             <div class="mb-3">
                                 <label class="form-label">Период дохода</label>
-                                <select name="IncomePeriod" class="form-select">
+                                <select asp-for="SearchData.SalaryPeriod" class="form-select">
                                     <option value="">Любой</option>
-                                    <option>месяц</option>
-                                    <option>час</option>
-                                    <option>смена</option>
-                                    <option>услуга</option>
-                                    <option>вахта</option>
+                                    <option value="месяц">месяц</option>
+                                    <option value="час">час</option>
+                                    <option value="смена">смена</option>
+                                    <option value="услуга">услуга</option>
+                                    <option value="вахта">вахта</option>
                                 </select>
                             </div>
 
                             <div class="mb-3">
                                 <label class="form-label">Частота выплат</label>
-                                <select name="PaymentFrequency" class="form-select">
+                                <select asp-for="SearchData.PaymentFrequency" class="form-select">
                                     <option value="">Любая</option>
-                                    <option>еженедельно</option>
-                                    <option>2 раза в месяц</option>
-                                    <option>ежемесячно</option>
+                                    <option value="еженедельно">еженедельно</option>
+                                    <option value="2 раза в месяц">2 раза в месяц</option>
+                                    <option value="ежемесячно">ежемесячно</option>
                                 </select>
                             </div>
 
@@ -102,13 +102,11 @@
 
                             <div class="mb-4">
                                 <label class="form-label">Специальность</label>
-                                <select name="Specialty" class="form-select">
+                                <select asp-for="SearchData.Specialty" class="form-select">
                                     <option value="">Любая</option>
                                     @foreach (var specialty in WebReckrytingSystem.Models.SpecialtyCatalog.All)
                                     {
-                                        <option value="@specialty" selected="@(Request.Query["Specialty"] == specialty)">
-                                            @specialty
-                                        </option>
+                                        <option value="@specialty">@specialty</option>
                                     }
                                 </select>
                             </div>

--- a/WebReckrytingSystem/Pages/Vacancy/Search.cshtml
+++ b/WebReckrytingSystem/Pages/Vacancy/Search.cshtml
@@ -55,10 +55,10 @@
                                 <label class="form-label">Формат работы</label>
                                 <select asp-for="SearchData.WorkFormat" class="form-select">
                                     <option value="">Любой</option>
-                                    <option value="на месте работодателя">на месте работодателя</option>
-                                    <option value="удалённая">удалённая</option>
-                                    <option value="разъездная">разъездная</option>
-                                    <option value="гибрид">гибрид</option>
+                                    <option value="office">В офисе</option>
+                                    <option value="remote">Удалённо</option>
+                                    <option value="travel">Разъездной</option>
+                                    <option value="hybrid">Гибрид</option>
                                 </select>
                             </div>
 

--- a/WebReckrytingSystem/Pages/Vacancy/Search.cshtml
+++ b/WebReckrytingSystem/Pages/Vacancy/Search.cshtml
@@ -104,11 +104,12 @@
                                 <label class="form-label">Специальность</label>
                                 <select name="Specialty" class="form-select">
                                     <option value="">Любая</option>
-                                    <option>Информационные системы и программирование</option>
-                                    <option>Сетевое и системное администрирование</option>
-                                    <option>Экономика и бухгалтерский учет</option>
-                                    <option>Дизайн</option>
-                                    <option>Маркетинг</option>
+                                    @foreach (var specialty in WebReckrytingSystem.Models.SpecialtyCatalog.All)
+                                    {
+                                        <option value="@specialty" selected="@(Request.Query["Specialty"] == specialty)">
+                                            @specialty
+                                        </option>
+                                    }
                                 </select>
                             </div>
 

--- a/WebReckrytingSystem/Pages/Vacancy/Search.cshtml.cs
+++ b/WebReckrytingSystem/Pages/Vacancy/Search.cshtml.cs
@@ -78,10 +78,16 @@ namespace WebReckrytingSystem.Pages.Vacancy
                 var query = new QueryBuilder();
                 AddIfNotEmpty(query, "Keywords", SearchData.Keywords);
                 AddIfNotEmpty(query, "CompanyName", SearchData.CompanyName);
+                AddIfNotEmpty(query, "Region", SearchData.Region);
                 AddIfNotNull(query, "SalaryFrom", SearchData.SalaryFrom);
                 AddIfNotNull(query, "SalaryTo", SearchData.SalaryTo);
                 AddIfNotEmpty(query, "EmploymentType", SearchData.EmploymentType);
                 AddIfNotEmpty(query, "WorkSchedule", SearchData.WorkSchedule);
+                AddIfNotNull(query, "WorkHoursPerDay", SearchData.WorkHoursPerDay);
+                AddIfNotEmpty(query, "WorkFormat", SearchData.WorkFormat);
+                AddIfNotEmpty(query, "SalaryPeriod", SearchData.SalaryPeriod);
+                AddIfNotEmpty(query, "PaymentFrequency", SearchData.PaymentFrequency);
+                AddIfNotEmpty(query, "Specialty", SearchData.Specialty);
                 query.Add("Page", SearchData.Page.ToString());
                 query.Add("PageSize", SearchData.PageSize.ToString());
 

--- a/WebReckrytingSystem/Services/VacancySearchService.cs
+++ b/WebReckrytingSystem/Services/VacancySearchService.cs
@@ -84,6 +84,9 @@ namespace WebReckrytingSystem.Services
                     return ServiceResult.Error("Недопустимый график работы");
             }
 
+            if (model.WorkHoursPerDay.HasValue && (model.WorkHoursPerDay < 1 || model.WorkHoursPerDay > 24))
+                return ServiceResult.Error("Рабочие часы в день должны быть от 1 до 24");
+
             // Валидация пагинации
             if (model.Page < 1 || model.Page > 100)
                 return ServiceResult.Error("Некорректный номер страницы");
@@ -119,6 +122,13 @@ namespace WebReckrytingSystem.Services
                     v.CompanyName.Contains(model.CompanyName, StringComparison.OrdinalIgnoreCase));
             }
 
+            if (!string.IsNullOrWhiteSpace(model.Region))
+            {
+                filtered = filtered.Where(v =>
+                    !string.IsNullOrWhiteSpace(v.Region) &&
+                    v.Region.Contains(model.Region, StringComparison.OrdinalIgnoreCase));
+            }
+
             // Фильтр по зарплате
             if (model.SalaryFrom.HasValue)
             {
@@ -142,6 +152,31 @@ namespace WebReckrytingSystem.Services
             if (!string.IsNullOrEmpty(model.WorkSchedule))
             {
                 filtered = filtered.Where(v => v.WorkSchedule == model.WorkSchedule);
+            }
+
+            if (model.WorkHoursPerDay.HasValue)
+            {
+                filtered = filtered.Where(v => v.WorkHoursPerDay == model.WorkHoursPerDay);
+            }
+
+            if (!string.IsNullOrWhiteSpace(model.WorkFormat))
+            {
+                filtered = filtered.Where(v => v.WorkFormat == model.WorkFormat);
+            }
+
+            if (!string.IsNullOrWhiteSpace(model.SalaryPeriod))
+            {
+                filtered = filtered.Where(v => v.SalaryPeriod == model.SalaryPeriod);
+            }
+
+            if (!string.IsNullOrWhiteSpace(model.PaymentFrequency))
+            {
+                filtered = filtered.Where(v => v.PaymentFrequency == model.PaymentFrequency);
+            }
+
+            if (!string.IsNullOrWhiteSpace(model.Specialty))
+            {
+                filtered = filtered.Where(v => v.Specialty == model.Specialty);
             }
 
             return filtered.ToList();

--- a/WebReckrytingSystem/Services/VacancyService.cs
+++ b/WebReckrytingSystem/Services/VacancyService.cs
@@ -128,7 +128,7 @@ namespace WebReckrytingSystem.Services
                 return ServiceResult.Error("Недопустимый тип занятости");
 
             var validWorkSchedules = new[] { "full_day", "shifts", "flexible", "remote", "shift_work" };
-            var validWorkFormats = new[] { "office", "remote", "hybrid" };
+            var validWorkFormats = new[] { "office", "remote", "travel", "hybrid" };
             var validSalaryPeriods = new[] { "month", "hour", "shift", "service", "rotation" };
             var validPaymentFrequencies = new[] { "weekly", "biweekly", "monthly", "after_shift", "contract" };
             if (!validWorkSchedules.Contains(model.WorkSchedule))


### PR DESCRIPTION
### Motivation
- Employers could trigger `MySqlException: Cannot add foreign key constraint` when opening a resume if the `saved_resumes` table was created at runtime with a `FOREIGN KEY` that fails to be added on some existing schemas, causing an unhandled exception in the employer-only code path.

### Description
- Removed the runtime `CONSTRAINT fk_saved_resumes_resume FOREIGN KEY (...)` clause from the `CREATE TABLE IF NOT EXISTS saved_resumes` SQL used in `WebReckrytingSystem/Pages/Resume/Details.cshtml.cs` and `WebReckrytingSystem/Pages/Account/Favorites.cshtml.cs`, leaving only the indexes and unique key so the table can be created without attempting to add the FK.

### Testing
- Attempted to run `dotnet build` in the container but the command failed with `dotnet: command not found`, so no build/test run could be performed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6df867d6083339d8073d4527d0dfe)