### PR TITLE
Автообновление результатов при изменении фильтров вакансий

### DIFF
--- a/WebReckrytingSystem/Pages/Vacancy/Search.cshtml
+++ b/WebReckrytingSystem/Pages/Vacancy/Search.cshtml
@@ -184,6 +184,60 @@
     </div>
 </div>
 
+@section Scripts {
+    <script>
+        (() => {
+            const form = document.getElementById('searchForm');
+            if (!form) {
+                return;
+            }
+
+            const autoSubmitSelectors = [
+                'input[name="SearchData.Keywords"]',
+                'input[name="SearchData.Region"]',
+                'input[name="SearchData.WorkHoursPerDay"]',
+                'input[name="SearchData.SalaryFrom"]',
+                'input[name="SearchData.SalaryTo"]',
+                'input[name="SearchData.CompanyName"]',
+                'select[name="SearchData.WorkSchedule"]',
+                'select[name="SearchData.WorkFormat"]',
+                'select[name="SearchData.SalaryPeriod"]',
+                'select[name="SearchData.PaymentFrequency"]',
+                'select[name="SearchData.Specialty"]'
+            ];
+
+            const controls = form.querySelectorAll(autoSubmitSelectors.join(','));
+            const pageInput = form.querySelector('input[name="SearchData.Page"]');
+            let debounceTimer;
+
+            const submitSearch = () => {
+                if (pageInput) {
+                    pageInput.value = '1';
+                }
+
+                form.requestSubmit();
+            };
+
+            const debouncedSubmit = () => {
+                window.clearTimeout(debounceTimer);
+                debounceTimer = window.setTimeout(submitSearch, 400);
+            };
+
+            controls.forEach(control => {
+                if (control.tagName === 'SELECT') {
+                    control.addEventListener('change', submitSearch);
+                    return;
+                }
+
+                if (control.type === 'number' || control.type === 'text') {
+                    control.addEventListener('input', debouncedSubmit);
+                    control.addEventListener('change', submitSearch);
+                }
+            });
+        })();
+    </script>
+}
+
 @functions {
     string Truncate(string text, int maxLength)
     {


### PR DESCRIPTION
### Motivation
- Сделать так, чтобы поиск вакансий автоматически обновлялся при изменении любых фильтров, чтобы пользователю не нужно было вручную нажимать кнопку «Найти». 

### Description
- Добавлен клиентский скрипт в `WebReckrytingSystem/Pages/Vacancy/Search.cshtml`, который отслеживает изменения фильтров и автоматически отправляет форму. 
- Для `select`-полей используется немедленная отправка по событию `change`, а для текстовых и числовых полей реализован дебаунс по `input` с задержкой 400 мс и отправка по `change`. 
- Перед автопоиском скрытое поле `SearchData.Page` сбрасывается в `1`, и отправка выполняется через `form.requestSubmit()` для корректного построения GET-запроса. 

### Testing
- Попытка выполнить `dotnet build WebReckrytingSystem/WebReckrytingSystem.sln` завершилась неудачно из‑за отсутствия `dotnet` в окружении (`/bin/bash: line 1: dotnet: command not found`).
- Другие автоматизированные тесты не запускались в этом окружении.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfec0b15c483338c585b347a7649fe)