### PR TITLE
Improve dark theme on auth and home pages

### DIFF
--- a/WebReckrytingSystem/Pages/Account/Login.cshtml
+++ b/WebReckrytingSystem/Pages/Account/Login.cshtml
@@ -1,4 +1,4 @@
-﻿@page
+@page
 @model WebReckrytingSystem.Pages.Account.LoginModel
 @{
     ViewData["Title"] = "Вход - Твоя Карьера";
@@ -10,7 +10,7 @@
             <!-- ЛЕВАЯ ЧАСТЬ: ФОРМА -->
             <div class="login-form-section">
                 <div class="brand">
-                    <img src="~/images/logo.png" alt="Твоя Карьера" class="brand-logo" />
+                    <img src="~/images/logotip.png" alt="Твоя Карьера" class="brand-logo" />
                     <h2 class="brand-name">Твоя Карьера</h2>
                     <p class="brand-tagline">Войдите в свой аккаунт</p>
                 </div>
@@ -221,6 +221,60 @@
 
         }
 
+
+        :root[data-theme='dark'] .login-card {
+            background: #1a1f29;
+            color: #e9edf5;
+            box-shadow: 0 20px 60px rgba(0,0,0,0.55);
+        }
+
+        :root[data-theme='dark'] .login-form-section {
+            background: #1a1f29;
+        }
+
+        :root[data-theme='dark'] .brand-name {
+            background: linear-gradient(135deg, #9fb2ff, #c7a6ff);
+            -webkit-background-clip: text;
+            -webkit-text-fill-color: transparent;
+            background-clip: text;
+        }
+
+        :root[data-theme='dark'] .brand-tagline,
+        :root[data-theme='dark'] .login-form-section p,
+        :root[data-theme='dark'] .login-form-section .form-label,
+        :root[data-theme='dark'] .login-form-section .form-check-label {
+            color: #dbe3f2;
+        }
+
+        :root[data-theme='dark'] .login-form-section .form-control {
+            background-color: #ffffff;
+            color: #212529;
+            border-color: #cfd6e4;
+        }
+
+        :root[data-theme='dark'] .login-form-section .form-control:focus {
+            background-color: #ffffff;
+            color: #212529;
+            border-color: #9fb2ff;
+            box-shadow: 0 0 0 0.25rem rgba(159, 178, 255, 0.25);
+        }
+
+        :root[data-theme='dark'] .login-form-section .form-control::placeholder {
+            color: #6c757d;
+        }
+
+        :root[data-theme='dark'] .login-form-section .btn-outline-secondary {
+            background-color: #ffffff;
+            color: #212529;
+            border-color: #cfd6e4;
+        }
+
+        :root[data-theme='dark'] .login-form-section input:-webkit-autofill,
+        :root[data-theme='dark'] .login-form-section input:-webkit-autofill:hover,
+        :root[data-theme='dark'] .login-form-section input:-webkit-autofill:focus {
+            -webkit-text-fill-color: #212529;
+            box-shadow: 0 0 0 1000px #ffffff inset;
+        }
         #togglePassword {
             cursor: pointer;
         }

--- a/WebReckrytingSystem/Pages/Account/Login.cshtml
+++ b/WebReckrytingSystem/Pages/Account/Login.cshtml
@@ -153,7 +153,7 @@
         }
 
         .login-info-section {
-            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            background: linear-gradient(135deg, #4257d8 0%, #5d2f8c 100%);
             color: white;
             padding: 3rem;
             display: flex;
@@ -230,6 +230,11 @@
 
         :root[data-theme='dark'] .login-form-section {
             background: #1a1f29;
+        }
+
+        :root[data-theme='dark'] .login-info-section {
+            background: linear-gradient(135deg, #23305d 0%, #43215f 100%);
+            border-left: 1px solid rgba(255, 255, 255, 0.08);
         }
 
         :root[data-theme='dark'] .brand-name {

--- a/WebReckrytingSystem/Pages/Account/Register.cshtml
+++ b/WebReckrytingSystem/Pages/Account/Register.cshtml
@@ -1,4 +1,4 @@
-﻿@page
+@page
 @model WebReckrytingSystem.Pages.Account.RegisterModel
 @{
     ViewData["Title"] = "Регистрация - Твоя Карьера";
@@ -9,7 +9,7 @@
         <div class="register-card">
             <div class="register-form-section">
                 <div class="brand text-center mb-4">
-                                  <h2 class="brand-name">Регистрация</h2>
+                    <h2 class="brand-name">Регистрация</h2>
                     <p class="brand-tagline">Начните карьеру за 60 секунд</p>
                 </div>
 
@@ -147,6 +147,65 @@
             }
         }
 
+
+        :root[data-theme='dark'] .register-card {
+            background: #1a1f29;
+            color: #e9edf5;
+            box-shadow: 0 20px 60px rgba(0,0,0,0.55);
+        }
+
+        :root[data-theme='dark'] .register-form-section {
+            background: #1a1f29;
+        }
+
+        :root[data-theme='dark'] .brand-name {
+            background: linear-gradient(135deg, #9fb2ff, #c7a6ff);
+            -webkit-background-clip: text;
+            -webkit-text-fill-color: transparent;
+            background-clip: text;
+        }
+
+        :root[data-theme='dark'] .brand-tagline,
+        :root[data-theme='dark'] .register-form-section p,
+        :root[data-theme='dark'] .register-form-section .form-label {
+            color: #dbe3f2;
+        }
+
+        :root[data-theme='dark'] .register-form-section .form-control {
+            background-color: #ffffff;
+            color: #212529;
+            border-color: #cfd6e4;
+        }
+
+        :root[data-theme='dark'] .register-form-section .form-control:focus {
+            background-color: #ffffff;
+            color: #212529;
+            border-color: #9fb2ff;
+            box-shadow: 0 0 0 0.25rem rgba(159, 178, 255, 0.25);
+        }
+
+        :root[data-theme='dark'] .register-form-section .form-control::placeholder {
+            color: #6c757d;
+        }
+
+        :root[data-theme='dark'] .register-form-section .btn-outline-secondary {
+            background-color: #ffffff;
+            color: #212529;
+            border-color: #cfd6e4;
+        }
+
+        :root[data-theme='dark'] .register-form-section .alert-info {
+            background-color: #202b3f;
+            border-color: #3b5277;
+            color: #dbeafe;
+        }
+
+        :root[data-theme='dark'] .register-form-section input:-webkit-autofill,
+        :root[data-theme='dark'] .register-form-section input:-webkit-autofill:hover,
+        :root[data-theme='dark'] .register-form-section input:-webkit-autofill:focus {
+            -webkit-text-fill-color: #212529;
+            box-shadow: 0 0 0 1000px #ffffff inset;
+        }
         .btn-check:checked + .btn-outline-primary {
             background-color: #667eea;
             border-color: #667eea;

--- a/WebReckrytingSystem/wwwroot/css/careerflow.css
+++ b/WebReckrytingSystem/wwwroot/css/careerflow.css
@@ -594,6 +594,25 @@ img,
     color: #e9edf5;
 }
 
+:root[data-theme='dark'] .users-section {
+    background: #0f1115;
+}
+
+:root[data-theme='dark'] .user-card,
+:root[data-theme='dark'] .step-card {
+    background: #1a1f29;
+    color: #e9edf5;
+    border: 1px solid #2d3442;
+    box-shadow: 0 12px 30px rgba(0, 0, 0, 0.35);
+}
+
+:root[data-theme='dark'] .user-card .card-body,
+:root[data-theme='dark'] .user-card .card-body p,
+:root[data-theme='dark'] .user-card .feature-list li,
+:root[data-theme='dark'] .step-card p {
+    color: #dbe3f2;
+}
+
 :root[data-theme='dark'] .navbar.fixed-top {
     background: rgba(18, 21, 28, 0.95) !important;
 }


### PR DESCRIPTION
### Motivation
- Fix dark-theme readability issues where the `users-section` and its cards remained light and unreadable in dark mode. 
- Ensure form fields on login and registration remain readable in dark theme (inputs were becoming black with invisible text). 
- Make the dark theme consistent on authentication pages and show the correct logo above the "Твоя Карьера" heading.

### Description
- Replaced the login page logo reference from `~/images/logo.png` to the existing `~/images/logotip.png` in `WebReckrytingSystem/Pages/Account/Login.cshtml` so the logo is visible above the text. 
- Added scoped dark-mode CSS rules inside `Login.cshtml` and `Register.cshtml` to style auth cards, headings, labels, alerts and to keep input fields light (so text remains readable), including focus and `-webkit-autofill` handling. 
- Extended the global dark-theme stylesheet `WebReckrytingSystem/wwwroot/css/careerflow.css` with rules for `:root[data-theme='dark'] .users-section`, `.user-card` and `.step-card` so the home page users section and cards render with dark backgrounds, readable text, borders and shadows. 
- Minor markup cleanup in `Register.cshtml` to fix heading indentation.

### Testing
- Ran `git diff --check` and verified no whitespace/conflict warnings; check succeeded. 
- Created a commit containing the changes (commit present locally). 
- Attempted `dotnet build WebReckrytingSystem/WebReckrytingSystem.sln` but it was not executed because `dotnet` is not available in the environment (build not run here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0276eaf904833384515383398da212)