### PR TITLE
Перенос полной формы редактирования резюме на страницу администратора

### DIFF
--- a/WebReckrytingSystem/Pages/Admin/ResumeEdit.cshtml
+++ b/WebReckrytingSystem/Pages/Admin/ResumeEdit.cshtml
@@ -5,106 +5,290 @@
     Layout = "_AdminLayout";
 }
 
-<div class="container-fluid">
+<div class="container py-4" style="padding-top: 104px !important;">
+    <!-- Шапка с заголовком -->
     <div class="d-flex justify-content-between align-items-center mb-4">
-        <h2>@ViewData["Title"]</h2>
-        <a asp-page="/Admin/Resumes" class="btn btn-outline-secondary">← Назад к списку</a>
+        <h1 class="h2 fw-bold">
+            <i class="fas fa-edit text-primary me-2"></i>Редактирование резюме
+        </h1>
+        <a href="/Admin/Resumes" class="btn btn-outline-secondary rounded-pill px-4">
+            <i class="fas fa-arrow-left me-2"></i>Назад
+        </a>
     </div>
 
-    @if (!string.IsNullOrEmpty(Model.ErrorMessage))
-    {
-        <div class="alert alert-danger">@Model.ErrorMessage</div>
-    }
+    <div class="row justify-content-center">
+        <div class="col-lg-10">
+            <form method="post" id="resumeForm" novalidate>
+                <div asp-validation-summary="All" class="alert alert-danger rounded-pill @(ViewData.ModelState.ErrorCount > 0 ? "" : "d-none")"></div>
 
-    <form method="post">
-        <div class="row">
+                <!-- Основная информация (2 колонки) -->
+                <div class="row g-4">
+                    <!-- Левая колонка -->
+                    <div class="col-md-6">
+                        <div class="card border-0 shadow-sm rounded-4 h-100">
+                            <div class="card-header bg-transparent border-0 pt-4 px-4">
+                                <h5 class="fw-bold mb-0">
+                                    <i class="fas fa-id-card text-primary me-2"></i>Основная информация
+                                </h5>
+                            </div>
+                            <div class="card-body p-4 pt-2">
+                                <div class="mb-3">
+                                    <label asp-for="ResumeData.DesiredPosition" class="form-label fw-600">Желаемая должность *</label>
+                                    <input asp-for="ResumeData.DesiredPosition" class="form-control form-control-lg rounded-pill" placeholder=".NET Developer" />
+                                    <span asp-validation-for="ResumeData.DesiredPosition" class="text-danger small"></span>
+                                </div>
+
+                                <div class="mb-3">
+                                    <label asp-for="ResumeData.SalaryExpectations" class="form-label fw-600">Зарплатные ожидания (руб.)</label>
+                                    <input asp-for="ResumeData.SalaryExpectations" type="number" class="form-control form-control-lg rounded-pill" min="0" max="9999999" placeholder="100000" />
+                                    <span asp-validation-for="ResumeData.SalaryExpectations" class="text-danger small"></span>
+                                </div>
+
+                                <div class="mb-3">
+                                    <label asp-for="ResumeData.Specialty" class="form-label fw-600">Специальность *</label>
+                                    <select asp-for="ResumeData.Specialty" class="form-select form-select-lg rounded-pill" required>
+                                        <option value="">Выберите специальность</option>
+                                        @foreach (var specialty in Model.Specialties)
+                                        {
+                                            <option value="@specialty">@specialty</option>
+                                        }
+                                    </select>
+                                    <span asp-validation-for="ResumeData.Specialty" class="text-danger small"></span>
+                                </div>
+
+                                <div class="mb-3">
+                                    <label asp-for="ResumeData.City" class="form-label fw-600">Город *</label>
+                                    <input asp-for="ResumeData.City" class="form-control form-control-lg rounded-pill" placeholder="Москва" required />
+                                    <span asp-validation-for="ResumeData.City" class="text-danger small"></span>
+                                </div>
+
+                                <div class="mb-3">
+                                    <label asp-for="ResumeData.BusinessTripReadiness" class="form-label fw-600">Готовность к командировкам *</label>
+                                    <select asp-for="ResumeData.BusinessTripReadiness" class="form-select form-select-lg rounded-pill" required>
+                                        <option value="">Выберите вариант</option>
+                                        <option value="yes">Да</option>
+                                        <option value="no">Нет</option>
+                                        <option value="sometimes">Иногда</option>
+                                    </select>
+                                    <span asp-validation-for="ResumeData.BusinessTripReadiness" class="text-danger small"></span>
+                                </div>
+
+                                <div class="mb-3">
+                                    <label asp-for="ResumeData.SearchStatus" class="form-label fw-600">Статус поиска *</label>
+                                    <select asp-for="ResumeData.SearchStatus" class="form-select form-select-lg rounded-pill" required>
+                                        <option value="">Выберите статус</option>
+                                        <option>активно ищет</option>
+                                        <option>рассматривает</option>
+                                        <option>не ищет</option>
+                                        <option>получил предложение</option>
+                                        <option>вышел на работу</option>
+                                    </select>
+                                    <span asp-validation-for="ResumeData.SearchStatus" class="text-danger small"></span>
+                                </div>
+
+                                <div class="mb-3">
+                                    <label asp-for="ResumeData.Age" class="form-label fw-600">Возраст *</label>
+                                    <input asp-for="ResumeData.Age" type="number" class="form-control form-control-lg rounded-pill" min="14" max="100" placeholder="22" required />
+                                    <span asp-validation-for="ResumeData.Age" class="text-danger small"></span>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- Правая колонка -->
+                    <div class="col-md-6">
+                        <div class="card border-0 shadow-sm rounded-4 h-100">
+                            <div class="card-header bg-transparent border-0 pt-4 px-4">
+                                <h5 class="fw-bold mb-0">
+                                    <i class="fas fa-briefcase text-primary me-2"></i>Работа и авто
+                                </h5>
+                            </div>
+                            <div class="card-body p-4 pt-2">
+                                <div class="mb-3">
+                                    <label asp-for="ResumeData.EmploymentType" class="form-label fw-600">Тип занятости *</label>
+                                    <select asp-for="ResumeData.EmploymentType" class="form-select form-select-lg rounded-pill" required>
+                                        <option value="">Выберите тип занятости</option>
+                                        <option>полная занятость</option>
+                                        <option>частичная занятость</option>
+                                        <option>проектная</option>
+                                        <option>волонтерство</option>
+                                        <option>стажировка</option>
+                                    </select>
+                                    <span asp-validation-for="ResumeData.EmploymentType" class="text-danger small"></span>
+                                </div>
+
+                                <div class="mb-3">
+                                    <label asp-for="ResumeData.WorkSchedule" class="form-label fw-600">График работы *</label>
+                                    <select asp-for="ResumeData.WorkSchedule" class="form-select form-select-lg rounded-pill" required>
+                                        <option value="">Выберите график</option>
+                                        <option>полный день</option>
+                                        <option>сменный график</option>
+                                        <option>гибкий график</option>
+                                        <option>удаленная работа</option>
+                                        <option>вахтовый метод</option>
+                                    </select>
+                                    <span asp-validation-for="ResumeData.WorkSchedule" class="text-danger small"></span>
+                                </div>
+
+                                <div class="mb-3">
+                                    <label asp-for="ResumeData.Gender" class="form-label fw-600">Пол *</label>
+                                    <select asp-for="ResumeData.Gender" class="form-select form-select-lg rounded-pill" required>
+                                        <option value="">Выберите пол</option>
+                                        <option>мужской</option>
+                                        <option>женский</option>
+                                    </select>
+                                    <span asp-validation-for="ResumeData.Gender" class="text-danger small"></span>
+                                </div>
+
+                                <div class="mb-3">
+                                    <label asp-for="ResumeData.ExperienceYears" class="form-label fw-600">Опыт работы (лет)</label>
+                                    <input asp-for="ResumeData.ExperienceYears" type="number" class="form-control form-control-lg rounded-pill" min="0" max="60" placeholder="3" />
+                                    <span asp-validation-for="ResumeData.ExperienceYears" class="text-danger small"></span>
+                                </div>
+
+                                <div class="mb-3">
+                                    <label asp-for="ResumeData.HasCar" class="form-label fw-600">Наличие автомобиля</label>
+                                    <select asp-for="ResumeData.HasCar" class="form-select form-select-lg rounded-pill">
+                                        <option value="false">Нет</option>
+                                        <option value="true">Есть</option>
+                                    </select>
+                                    <span asp-validation-for="ResumeData.HasCar" class="text-danger small"></span>
+                                </div>
+
+                                <div class="mb-3">
+                                    <label asp-for="ResumeData.DriverLicenseCategories" class="form-label fw-600">Категория(и) прав</label>
+                                    <div class="dropdown" data-bs-auto-close="outside" data-target-select="editDriverLicenseCategories">
+                                        <button class="btn btn-outline-secondary dropdown-toggle w-100 text-start" type="button" data-bs-toggle="dropdown" aria-expanded="false">
+                                            Выберите категории прав
+                                        </button>
+                                        <ul class="dropdown-menu w-100 shadow-sm p-2">
+                                            @foreach (var category in Model.DriverLicenseCategories)
+                                            {
+                                                <li>
+                                                    <button type="button" class="dropdown-item d-flex justify-content-between align-items-center rounded-3" data-license-value="@category">
+                                                        <span>@category</span>
+                                                        <i class="fas fa-check text-success d-none"></i>
+                                                    </button>
+                                                </li>
+                                            }
+                                        </ul>
+                                    </div>
+                                    <select asp-for="ResumeData.DriverLicenseCategories" id="editDriverLicenseCategories" class="d-none" multiple>
+                                        @foreach (var category in Model.DriverLicenseCategories)
+                                        {
+                                            <option value="@category">@category</option>
+                                        }
+                                    </select>
+                                    <span asp-validation-for="ResumeData.DriverLicenseCategories" class="text-danger small"></span>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Опыт работы (полная ширина) -->
+                <div class="card border-0 shadow-sm rounded-4 mt-4">
+                    <div class="card-header bg-transparent border-0 pt-4 px-4">
+                        <h5 class="fw-bold mb-0">
+                            <i class="fas fa-briefcase text-primary me-2"></i>Опыт работы
+                        </h5>
+                    </div>
+                    <div class="card-body p-4 pt-2">
+                        <textarea asp-for="ResumeData.ExperienceDescription" class="form-control rounded-3" rows="4" maxlength="1000" placeholder="Ключевые проекты и достижения"></textarea>
+                        <span asp-validation-for="ResumeData.ExperienceDescription" class="text-danger small"></span>
+                    </div>
+                </div>
+
+                <!-- Образование -->
+                <!-- Внутри карточки "Образование" -->
+<!-- Образование -->
+<div class="card border-0 shadow-sm rounded-4 mt-4">
+    <div class="card-header bg-transparent border-0 pt-4 px-4">
+        <h5 class="fw-bold mb-0">
+            <i class="fas fa-graduation-cap text-primary me-2"></i>Образование
+        </h5>
+    </div>
+    <div class="card-body p-4 pt-2">
+        <div class="row g-3">
             <div class="col-md-6">
-                <div class="card shadow-sm mb-4">
-                    <div class="card-header bg-light">
-                        <h5 class="mb-0">Основная информация</h5>
-                    </div>
-                    <div class="card-body">
-                        <div class="mb-3">
-                            <label asp-for="ResumeData.DesiredPosition" class="form-label">Желаемая должность *</label>
-                            <input asp-for="ResumeData.DesiredPosition" class="form-control" required />
-                        </div>
-                        <div class="mb-3">
-                            <label asp-for="ResumeData.SalaryExpectations" class="form-label">Зарплатные ожидания</label>
-                            <input asp-for="ResumeData.SalaryExpectations" type="number" class="form-control" />
-                        </div>
-                        <div class="mb-3 form-check">
-                            <input asp-for="ResumeData.IsPublished" class="form-check-input" />
-                            <label asp-for="ResumeData.IsPublished" class="form-check-label">
-                                Опубликовано
-                            </label>
-                        </div>
-                    </div>
-                </div>
+                <label asp-for="ResumeData.Specialty" class="form-label fw-600">Специальность *</label>
+                <select asp-for="ResumeData.Specialty" class="form-select form-select-lg rounded-pill" required>
+                    <option value="">Выберите специальность</option>
+                    @foreach (var specialty in Model.Specialties)
+                    {
+                        <option value="@specialty">@specialty</option>
+                    }
+                </select>
+                <span asp-validation-for="ResumeData.Specialty" class="text-danger small"></span>
             </div>
-
             <div class="col-md-6">
-                <div class="card shadow-sm mb-4">
-                    <div class="card-header bg-light">
-                        <h5 class="mb-0">Навыки</h5>
-                    </div>
-                    <div class="card-body">
-                        <textarea asp-for="ResumeData.Skills" class="form-control" rows="5"
-                                  placeholder="C#, ASP.NET, SQL"></textarea>
-                        <small class="form-text text-muted">Через запятую</small>
-                    </div>
-                </div>
+                <label asp-for="ResumeData.EducationalInstitution" class="form-label fw-600">Учебное заведение *</label>
+                <input asp-for="ResumeData.EducationalInstitution" class="form-control rounded-pill bg-light text-muted" readonly />
+                <small class="form-text text-muted">Учебное заведение установлено автоматически и не может быть изменено.</small>
+                <span asp-validation-for="ResumeData.EducationalInstitution" class="text-danger small"></span>
             </div>
+            <div class="col-md-6">
+                <label asp-for="ResumeData.GraduationYear" class="form-label fw-600">Год окончания</label>
+                <input asp-for="ResumeData.GraduationYear" type="number" class="form-control rounded-pill" min="1900" max="2025" placeholder="2023" />
+                <span asp-validation-for="ResumeData.GraduationYear" class="text-danger small"></span>
+            </div>
+        </div>
+    </div>
+</div>
 
-            <div class="col-12">
-                <div class="card shadow-sm mb-4">
-                    <div class="card-header bg-light">
-                        <h5 class="mb-0">Описание опыта</h5>
+                <!-- Навыки -->
+                <div class="card border-0 shadow-sm rounded-4 mt-4">
+                    <div class="card-header bg-transparent border-0 pt-4 px-4">
+                        <h5 class="fw-bold mb-0">
+                            <i class="fas fa-code text-primary me-2"></i>Ключевые навыки
+                        </h5>
                     </div>
-                    <div class="card-body">
-                        <textarea asp-for="ResumeData.ExperienceDescription" class="form-control" rows="4"></textarea>
-                    </div>
-                </div>
-
-                <div class="card shadow-sm mb-4">
-                    <div class="card-header bg-light">
-                        <h5 class="mb-0">Образование</h5>
-                    </div>
-                    <div class="card-body">
-                        <textarea asp-for="ResumeData.EducationDescription" class="form-control" rows="4"></textarea>
+                    <div class="card-body p-4 pt-2">
+                        <div class="mb-3">
+                            <input id="skillsInput" class="form-control rounded-pill" placeholder="C#, ASP.NET, SQL и нажмите Enter" autocomplete="off">
+                            <small class="form-text text-muted">Нажмите Enter после каждого навыка. Макс. 20.</small>
+                            <div id="skillsTags" class="mt-2"></div>
+                            <input type="hidden" name="SkillsHidden" id="skillsHidden" data-val="false" value='@System.Text.Json.JsonSerializer.Serialize(Model.ResumeData.Skills)'>
+                        </div>
                     </div>
                 </div>
 
                 <!-- Практики -->
-                <div class="card shadow-sm mb-4">
-                    <div class="card-header bg-light d-flex justify-content-between align-items-center">
-                        <h5 class="mb-0">Практики</h5>
-                        <button type="button" class="btn btn-sm btn-outline-primary" onclick="addPractice()">
+                <div class="card border-0 shadow-sm rounded-4 mt-4">
+                    <div class="card-header bg-transparent border-0 pt-4 px-4 d-flex justify-content-between align-items-center">
+                        <h5 class="fw-bold mb-0">
+                            <i class="fas fa-tasks text-primary me-2"></i>Практики во время учёбы
+                        </h5>
+                        <button type="button" class="btn btn-sm btn-outline-primary rounded-pill" onclick="addPractice()">
                             <i class="fas fa-plus me-1"></i> Добавить
                         </button>
                     </div>
-                    <div class="card-body" id="practicesContainer">
+                    <div class="card-body p-4 pt-2" id="practicesContainer">
                         @for (int i = 0; i < Model.ResumeData.Practices.Count; i++)
                         {
-                            <div class="card mb-2 p-3 practice-item">
-                                <div class="row g-2">
+                            <div class="card mb-3 p-3 practice-item border-0 bg-light">
+                                <div class="row g-3">
                                     <div class="col-md-6">
-                                        <label class="form-label">Место практики</label>
-                                        <input asp-for="ResumeData.Practices[i].Place" class="form-control" />
+                                        <label class="form-label fw-600">Место практики</label>
+                                        <input asp-for="ResumeData.Practices[i].Place" class="form-control rounded-pill" placeholder="ООО ТехноПрактик" />
+                                        <span asp-validation-for="ResumeData.Practices[i].Place" class="text-danger small"></span>
                                     </div>
                                     <div class="col-md-3">
-                                        <label class="form-label">С</label>
-                                        <input asp-for="ResumeData.Practices[i].StartDate" type="date" class="form-control" />
+                                        <label class="form-label fw-600">С</label>
+                                        <input asp-for="ResumeData.Practices[i].StartDate" type="date" class="form-control rounded-pill" />
+                                        <span asp-validation-for="ResumeData.Practices[i].StartDate" class="text-danger small"></span>
                                     </div>
                                     <div class="col-md-3">
-                                        <label class="form-label">По</label>
-                                        <input asp-for="ResumeData.Practices[i].EndDate" type="date" class="form-control" />
+                                        <label class="form-label fw-600">По</label>
+                                        <input asp-for="ResumeData.Practices[i].EndDate" type="date" class="form-control rounded-pill" />
+                                        <span asp-validation-for="ResumeData.Practices[i].EndDate" class="text-danger small"></span>
                                     </div>
                                     <div class="col-12">
-                                        <label class="form-label">Описание</label>
-                                        <textarea asp-for="ResumeData.Practices[i].Description" class="form-control" rows="2"></textarea>
+                                        <label class="form-label fw-600">Описание</label>
+                                        <textarea asp-for="ResumeData.Practices[i].Description" class="form-control rounded-3" rows="2" maxlength="500"></textarea>
                                     </div>
                                     <div class="col-12 text-end">
-                                        <button type="button" class="btn btn-sm btn-outline-danger" onclick="removePractice(this)">
+                                        <button type="button" class="btn btn-sm btn-outline-danger rounded-pill" onclick="removePractice(this)">
                                             <i class="fas fa-trash me-1"></i> Удалить практику
                                         </button>
                                     </div>
@@ -113,85 +297,181 @@
                         }
                     </div>
                 </div>
-            </div>
-        </div>
 
-        <div class="d-flex gap-2 mt-4">
-            <button type="submit" class="btn btn-primary">
-                <i class="fas fa-save"></i> Сохранить изменения
-            </button>
-            <a asp-page="/Admin/Resumes" class="btn btn-outline-secondary">Отмена</a>
+                <!-- Публикация и кнопки -->
+                <div class="row mt-4 align-items-center">
+                    <div class="col-md-6">
+                        <div class="form-check form-switch">
+                            <input asp-for="ResumeData.IsPublished" class="form-check-input" style="transform: scale(1.2);" />
+                            <label asp-for="ResumeData.IsPublished" class="form-check-label fw-600 ms-2">Опубликовать резюме (видно работодателям)</label>
+                        </div>
+                    </div>
+                    <div class="col-md-6 text-md-end mt-3 mt-md-0">
+                        <button type="submit" class="btn btn-success btn-lg rounded-pill px-5 me-2">
+                            <i class="fas fa-save me-2"></i>Сохранить изменения
+                        </button>
+                        <a href="/Admin/Resumes" class="btn btn-outline-secondary btn-lg rounded-pill px-4">Отмена</a>
+                    </div>
+                </div>
+            </form>
         </div>
-    </form>
+    </div>
 </div>
 
-@@section Scripts {
-<script>
-    function removePractice(btn) {
-        const card = btn.closest('.practice-item');
-        card.remove();
-        reindexPractices();
-    }
+@section Styles {
+    <style>
+        .card { border-radius: 1.5rem !important; }
+        .form-control-lg, .form-select-lg { font-size: 1rem; padding: 0.75rem 1.25rem; }
+        .btn-lg { padding: 0.75rem 2rem; }
+        .form-check-input:checked { background-color: var(--primary-color); border-color: var(--primary-color); }
+        #skillsTags .badge { font-size: 0.9rem; padding: 0.5rem 1rem; background-color: var(--primary-color) !important; }
+        #skillsTags .badge a { color: white; text-decoration: none; }
+        .practice-item { transition: all 0.2s ease; }
+        .practice-item:hover { box-shadow: 0 5px 15px rgba(0,0,0,0.1); }
+    </style>
+}
 
-    function reindexPractices() {
-        const container = document.getElementById('practicesContainer');
-        const cards = container.querySelectorAll('.practice-item');
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
 
-        cards.forEach((card, index) => {
-            // Обновляем индексы во всех input/textarea
-            const inputs = card.querySelectorAll('input, textarea');
-            inputs.forEach(input => {
-                const nameAttr = input.getAttribute('name');
-                if (nameAttr) {
-                    input.setAttribute('name', nameAttr.replace(/Practices\[\d+\]/, `Practices[${index}]`));
-                    input.setAttribute('id', input.getAttribute('id')?.replace(/Practices_\d+/, `Practices_${index}`));
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            const hidden = document.getElementById('skillsHidden');
+            let skills = [];
+            try { skills = JSON.parse(hidden.value || '[]'); } catch (e) { skills = []; }
+            window.skills = skills;
+
+            renderSkills();
+            initLicenseDropdown('editDriverLicenseCategories');
+
+            const inp = document.getElementById('skillsInput');
+            inp.addEventListener('keydown', (e) => {
+                if (e.key !== 'Enter') return;
+                e.preventDefault();
+                const v = inp.value.trim();
+                if (!v) return;
+                if (skills.includes(v)) return;
+                if (skills.length >= 20) {
+                    showToast('Максимум 20 навыков', 'error');
+                    return;
                 }
+                skills.push(v);
+                renderSkills();
+                inp.value = '';
             });
 
-            // Обновляем индексы в span (для валидации)
-            const spans = card.querySelectorAll('span[data-valmsg-for]');
-            spans.forEach(span => {
-                const forAttr = span.getAttribute('data-valmsg-for');
-                if (forAttr) {
-                    span.setAttribute('data-valmsg-for', forAttr.replace(/Practices\[\d+\]/, `Practices[${index}]`));
-                }
-            });
+            function renderSkills() {
+                const tags = document.getElementById('skillsTags');
+                tags.innerHTML = skills.map(s =>
+                    `<span class="badge bg-primary me-2 mb-2">${s}
+                         <a href="#" class="text-white ms-1" onclick="skills=skills.filter(x=>x!=='${s}');renderSkills();return false;">×</a>
+                     </span>`).join('');
+                hidden.value = JSON.stringify(skills);
+            }
         });
-    }
 
-    function addPractice() {
-        const container = document.getElementById('practicesContainer');
-        const index = container.children.length;
-        const div = document.createElement('div');
-        div.className = 'card mb-2 p-3 practice-item';
+        function removePractice(btn) {
+            const card = btn.closest('.practice-item');
+            card.remove();
+            reindexPractices();
+        }
 
-        div.innerHTML = `
-            <div class="row g-2">
-                <div class="col-md-6">
-                    <label class="form-label">Место практики</label>
-                    <input name="ResumeData.Practices[${index}].Place" class="form-control" />
-                </div>
-                <div class="col-md-3">
-                    <label class="form-label">С</label>
-                    <input name="ResumeData.Practices[${index}].StartDate" type="date" class="form-control" />
-                </div>
-                <div class="col-md-3">
-                    <label class="form-label">По</label>
-                    <input name="ResumeData.Practices[${index}].EndDate" type="date" class="form-control" />
-                </div>
-                <div class="col-12">
-                    <label class="form-label">Описание</label>
-                    <textarea name="ResumeData.Practices[${index}].Description" class="form-control" rows="2"></textarea>
-                </div>
-                <div class="col-12 text-end">
-                    <button type="button" class="btn btn-sm btn-outline-danger" onclick="removePractice(this)">
-                        <i class="fas fa-trash me-1"></i> Удалить практику
-                    </button>
-                </div>
-            </div>
-        `;
+        function reindexPractices() {
+            const container = document.getElementById('practicesContainer');
+            const cards = container.querySelectorAll('.practice-item');
+            cards.forEach((card, index) => {
+                const inputs = card.querySelectorAll('input, textarea');
+                inputs.forEach(input => {
+                    const nameAttr = input.getAttribute('name');
+                    if (nameAttr) {
+                        input.setAttribute('name', nameAttr.replace(/Practices\[\d+\]/, `Practices[${index}]`));
+                        input.setAttribute('id', input.getAttribute('id')?.replace(/Practices_\d+/, `Practices_${index}`));
+                    }
+                });
+                const spans = card.querySelectorAll('span[data-valmsg-for]');
+                spans.forEach(span => {
+                    const forAttr = span.getAttribute('data-valmsg-for');
+                    if (forAttr) {
+                        span.setAttribute('data-valmsg-for', forAttr.replace(/Practices\[\d+\]/, `Practices[${index}]`));
+                    }
+                });
+            });
+        }
 
-        container.appendChild(div);
-    }
-</script>
+        function addPractice() {
+            const container = document.getElementById('practicesContainer');
+            const index = container.children.length;
+            const div = document.createElement('div');
+            div.className = 'card mb-3 p-3 practice-item border-0 bg-light';
+            div.innerHTML = `
+                <div class="row g-3">
+                    <div class="col-md-6">
+                        <label class="form-label fw-600">Место практики</label>
+                        <input name="ResumeData.Practices[${index}].Place" class="form-control rounded-pill" placeholder="ООО ТехноПрактик" />
+                    </div>
+                    <div class="col-md-3">
+                        <label class="form-label fw-600">С</label>
+                        <input name="ResumeData.Practices[${index}].StartDate" type="date" class="form-control rounded-pill" />
+                    </div>
+                    <div class="col-md-3">
+                        <label class="form-label fw-600">По</label>
+                        <input name="ResumeData.Practices[${index}].EndDate" type="date" class="form-control rounded-pill" />
+                    </div>
+                    <div class="col-12">
+                        <label class="form-label fw-600">Описание</label>
+                        <textarea name="ResumeData.Practices[${index}].Description" class="form-control rounded-3" rows="2" maxlength="500"></textarea>
+                    </div>
+                    <div class="col-12 text-end">
+                        <button type="button" class="btn btn-sm btn-outline-danger rounded-pill" onclick="removePractice(this)">
+                            <i class="fas fa-trash me-1"></i> Удалить практику
+                        </button>
+                    </div>
+                </div>
+            `;
+            container.appendChild(div);
+        }
+
+        function initLicenseDropdown(selectId) {
+            const select = document.getElementById(selectId);
+            const container = document.querySelector(`[data-target-select="${selectId}"]`);
+            if (!select || !container) return;
+
+            const toggle = container.querySelector('[data-bs-toggle="dropdown"]');
+            const items = container.querySelectorAll('[data-license-value]');
+
+            const syncUi = () => {
+                const selected = Array.from(select.selectedOptions).map(o => o.value);
+                items.forEach(item => {
+                    const value = item.getAttribute('data-license-value');
+                    const isSelected = selected.includes(value);
+                    item.classList.toggle('active', isSelected);
+                    item.querySelector('.fa-check')?.classList.toggle('d-none', !isSelected);
+                });
+                toggle.textContent = selected.length
+                    ? `Выбрано категорий: ${selected.length}`
+                    : 'Выберите категории прав';
+            };
+
+            items.forEach(item => {
+                item.addEventListener('click', () => {
+                    const value = item.getAttribute('data-license-value');
+                    const option = Array.from(select.options).find(o => o.value === value);
+                    if (!option) return;
+                    option.selected = !option.selected;
+                    syncUi();
+                });
+            });
+
+            syncUi();
+        }
+
+        @if (!string.IsNullOrEmpty(Model.SuccessMessage))
+        {
+            <text>showToast('@Html.Raw(Model.SuccessMessage)', 'success');</text>
+        }
+        @if (!string.IsNullOrEmpty(Model.ErrorMessage))
+        {
+            <text>showToast('@Html.Raw(Model.ErrorMessage)', 'error');</text>
+        }
+    </script>
 }

--- a/WebReckrytingSystem/Pages/Admin/ResumeEdit.cshtml.cs
+++ b/WebReckrytingSystem/Pages/Admin/ResumeEdit.cshtml.cs
@@ -1,12 +1,10 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
-using Microsoft.EntityFrameworkCore;
 using System.Text.Json;
-using WebReckrytingSystem.Data;
+using System.Text.RegularExpressions;
 using WebReckrytingSystem.Models;
-using WebReckrytingSystem.Models.Admin; // Добавьте это
-using Microsoft.Extensions.Logging;
+using WebReckrytingSystem.Services;
 
 namespace WebReckrytingSystem.Pages.Admin
 {
@@ -14,95 +12,249 @@ namespace WebReckrytingSystem.Pages.Admin
     public class ResumeEditModel : PageModel
     {
         private readonly ApplicationDbContext _context;
-        private readonly ILogger<ResumeEditModel> _logger;
+        private readonly ISpecialtyService _specialtyService;
 
-        public ResumeEditModel(ApplicationDbContext context, ILogger<ResumeEditModel> logger)
+        public ResumeEditModel(ApplicationDbContext context, ISpecialtyService specialtyService)
         {
             _context = context;
-            _logger = logger;
+            _specialtyService = specialtyService;
         }
 
         [BindProperty]
-        public AdminResumeViewModel ResumeData { get; set; } = new(); // Используем новую модель
+        public CreateResumeViewModel ResumeData { get; set; } = new();
 
-        public string? ErrorMessage { get; set; }
+        public IReadOnlyList<string> Specialties { get; set; } = new List<string>();
+        public IReadOnlyList<string> DriverLicenseCategories => DriverLicenseCategoryCatalog.All;
 
-        public async Task<IActionResult> OnGetAsync(string email)
+        public IActionResult OnGet(string email)
         {
-            _logger.LogInformation($"=== OnGetAsync для {email} ===");
+            Specialties = _specialtyService.GetAllNames();
 
-            var resume = await _context.Resumes.Include(r => r.User).FirstOrDefaultAsync(r => r.UserEmail == email);
-            if (resume == null)
+            var existingResume = _context.Resumes.FirstOrDefault(r => r.UserEmail == email);
+            if (existingResume == null)
             {
-                _logger.LogWarning("Резюме не найдено!");
                 return NotFound();
             }
 
-            // Простое присвоение без промежуточных полей
-            ResumeData = new AdminResumeViewModel
-            {
-                DesiredPosition = resume.DesiredPosition,
-                SalaryExpectations = resume.SalaryExpectations,
-                ExperienceDescription = resume.ExperienceDescription,
-                EducationDescription = resume.EducationDescription, // Прямая строка
-                Skills = resume.Skills, // Прямая строка
-                IsPublished = resume.IsPublished
-            };
-
-            if (!string.IsNullOrEmpty(resume.PracticesJson))
-            {
-                ResumeData.Practices = JsonSerializer.Deserialize<List<PracticeViewModel>>(resume.PracticesJson) ?? new();
-            }
-
+            ResumeData = MapResumeToViewModel(existingResume);
             return Page();
         }
 
-        public async Task<IActionResult> OnPostAsync(string email)
+        public IActionResult OnPost(string email)
         {
-            _logger.LogInformation($"=== OnPostAsync для {email} ===");
-
-            var resume = await _context.Resumes.FindAsync(email);
-            if (resume == null)
+            var skillsHidden = Request.Form["SkillsHidden"].FirstOrDefault();
+            if (!string.IsNullOrWhiteSpace(skillsHidden))
             {
-                _logger.LogError("Резюме не найдено в POST!");
-                return NotFound();
+                try
+                {
+                    ResumeData.Skills = JsonSerializer.Deserialize<List<string>>(skillsHidden) ?? new List<string>();
+                }
+                catch
+                {
+                    ResumeData.Skills = new List<string>();
+                }
             }
 
+            ResumeData.EducationalInstitution = "Р¤Р“Р‘РћРЈ РљРѕР»Р»РµРґР¶ Р РѕСЃСЂРµР·РµСЂРІР°";
+            Specialties = _specialtyService.GetAllNames();
+            ModelState.Remove("ResumeData.Skills");
+
             if (!ModelState.IsValid)
-            {
-                _logger.LogWarning("ModelState не валиден:");
-                foreach (var error in ModelState)
-                {
-                    foreach (var err in error.Value.Errors)
-                    {
-                        _logger.LogWarning($"Ошибка в {error.Key}: {err.ErrorMessage}");
-                    }
-                }
                 return Page();
+
+            var existingResume = _context.Resumes.FirstOrDefault(r => r.UserEmail == email);
+            if (existingResume == null)
+                return NotFound();
+
+            existingResume.DesiredPosition = ResumeData.DesiredPosition.Trim();
+            existingResume.City = ResumeData.City.Trim();
+            existingResume.BusinessTripReadiness = ResumeData.BusinessTripReadiness;
+            existingResume.SearchStatus = ResumeData.SearchStatus;
+            existingResume.Age = ResumeData.Age;
+            existingResume.EmploymentType = ResumeData.EmploymentType;
+            existingResume.WorkSchedule = ResumeData.WorkSchedule;
+            existingResume.Specialty = ResumeData.Specialty.Trim();
+            existingResume.Gender = ResumeData.Gender;
+            existingResume.SalaryExpectations = ResumeData.SalaryExpectations;
+            existingResume.HasCar = ResumeData.HasCar;
+            existingResume.DriverLicenseCategory = FormatDriverLicenseCategories(ResumeData.DriverLicenseCategories);
+            existingResume.ExperienceDescription = FormatExperienceDescription(ResumeData);
+            existingResume.EducationDescription = FormatEducationDescription(ResumeData);
+            existingResume.Skills = string.Join(", ", ResumeData.Skills.Select(s => s.Trim()).Distinct());
+            existingResume.IsPublished = ResumeData.IsPublished;
+            existingResume.PracticesJson = JsonSerializer.Serialize(ResumeData.Practices);
+
+            _context.SaveChanges();
+
+            TempData["SuccessMessage"] = "Р РµР·СЋРјРµ СѓСЃРїРµС€РЅРѕ РѕР±РЅРѕРІР»РµРЅРѕ!";
+            return RedirectToPage("/Admin/Resumes");
+        }
+
+        private static CreateResumeViewModel MapResumeToViewModel(Resume resume)
+        {
+            var viewModel = new CreateResumeViewModel
+            {
+                DesiredPosition = resume.DesiredPosition,
+                City = resume.City,
+                BusinessTripReadiness = resume.BusinessTripReadiness,
+                SearchStatus = resume.SearchStatus,
+                Age = resume.Age,
+                EmploymentType = resume.EmploymentType,
+                WorkSchedule = resume.WorkSchedule,
+                Specialty = resume.Specialty,
+                Gender = resume.Gender,
+                SalaryExpectations = resume.SalaryExpectations,
+                HasCar = resume.HasCar,
+                DriverLicenseCategory = resume.DriverLicenseCategory,
+                DriverLicenseCategories = string.IsNullOrWhiteSpace(resume.DriverLicenseCategory)
+                    ? new List<string>()
+                    : resume.DriverLicenseCategory
+                        .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                        .ToList(),
+                IsPublished = resume.IsPublished,
+                Skills = string.IsNullOrWhiteSpace(resume.Skills)
+                    ? new List<string>()
+                    : resume.Skills.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToList()
+            };
+
+            MapEducation(viewModel, resume.EducationDescription);
+            MapExperience(viewModel, resume.ExperienceDescription);
+            MapPractices(viewModel, resume.PracticesJson);
+
+            return viewModel;
+        }
+
+        private static void MapEducation(CreateResumeViewModel viewModel, string? educationDescription)
+        {
+            if (string.IsNullOrWhiteSpace(educationDescription))
+            {
+                return;
+            }
+
+            var parts = educationDescription
+                .Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries)
+                .ToList();
+
+            if (parts.Count > 0)
+            {
+                viewModel.EducationalInstitution = parts[0];
+            }
+
+            var yearMatch = Regex.Match(educationDescription, @"\b\d{4}\b");
+            if (yearMatch.Success && int.TryParse(yearMatch.Value, out var year))
+            {
+                viewModel.GraduationYear = year;
+            }
+        }
+
+        private static void MapExperience(CreateResumeViewModel viewModel, string? experienceDescription)
+        {
+            if (string.IsNullOrWhiteSpace(experienceDescription))
+            {
+                return;
+            }
+
+            var lines = experienceDescription
+                .Split('\n', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries)
+                .ToList();
+
+            if (lines.Count == 0)
+            {
+                return;
+            }
+
+            var yearsMatch = Regex.Match(lines[0], @"^РћРїС‹С‚ СЂР°Р±РѕС‚С‹:\s*(\d+)\s*Р»РµС‚", RegexOptions.IgnoreCase);
+            if (yearsMatch.Success && int.TryParse(yearsMatch.Groups[1].Value, out var years))
+            {
+                viewModel.ExperienceYears = years;
+                lines.RemoveAt(0);
+            }
+
+            var practicesStartIndex = lines.FindIndex(line => line.StartsWith("РџСЂР°РєС‚РёРєРё:", StringComparison.OrdinalIgnoreCase));
+            if (practicesStartIndex >= 0)
+            {
+                lines = lines.Take(practicesStartIndex).ToList();
+            }
+
+            if (lines.Any())
+            {
+                viewModel.ExperienceDescription = string.Join(Environment.NewLine, lines);
+            }
+        }
+
+        private static void MapPractices(CreateResumeViewModel viewModel, string? practicesJson)
+        {
+            if (string.IsNullOrWhiteSpace(practicesJson))
+            {
+                return;
             }
 
             try
             {
-                // Обновляем прямо из ResumeData
-                resume.DesiredPosition = ResumeData.DesiredPosition.Trim();
-                resume.SalaryExpectations = ResumeData.SalaryExpectations;
-                resume.ExperienceDescription = ResumeData.ExperienceDescription?.Trim();
-                resume.EducationDescription = ResumeData.EducationDescription?.Trim();
-                resume.Skills = ResumeData.Skills?.Trim();
-                resume.IsPublished = ResumeData.IsPublished;
-                resume.PracticesJson = JsonSerializer.Serialize(ResumeData.Practices);
-
-                await _context.SaveChangesAsync();
-
-                TempData["SuccessMessage"] = "Резюме успешно обновлено!";
-                return RedirectToPage("/Admin/Resumes");
+                viewModel.Practices = JsonSerializer.Deserialize<List<PracticeViewModel>>(practicesJson) ?? new List<PracticeViewModel>();
             }
-            catch (Exception ex)
+            catch
             {
-                _logger.LogError(ex, "Ошибка при сохранении!");
-                ErrorMessage = $"Ошибка при сохранении: {ex.Message}";
-                return Page();
+                viewModel.Practices = new List<PracticeViewModel>();
             }
+        }
+
+        private static string? FormatExperienceDescription(CreateResumeViewModel model)
+        {
+            var parts = new List<string>();
+
+            if (model.ExperienceYears.HasValue)
+                parts.Add($"РћРїС‹С‚ СЂР°Р±РѕС‚С‹: {model.ExperienceYears} Р»РµС‚");
+
+            if (!string.IsNullOrWhiteSpace(model.ExperienceDescription))
+                parts.Add(model.ExperienceDescription.Trim());
+
+            var practicesText = FormatPractices(model.Practices);
+            if (practicesText != null)
+                parts.Add(practicesText);
+
+            return parts.Any() ? string.Join("\n", parts) : null;
+        }
+
+        private static string? FormatEducationDescription(CreateResumeViewModel model)
+        {
+            var parts = new List<string>();
+
+            if (!string.IsNullOrWhiteSpace(model.EducationalInstitution))
+            {
+                var education = model.EducationalInstitution.Trim();
+
+                if (model.GraduationYear.HasValue)
+                    education += $", {model.GraduationYear} Рі.";
+
+                parts.Add(education);
+            }
+
+            return parts.Any() ? string.Join("; ", parts) : null;
+        }
+
+        private static string? FormatDriverLicenseCategories(List<string> categories)
+        {
+            var validCategories = categories
+                .Where(c => !string.IsNullOrWhiteSpace(c))
+                .Select(c => c.Trim().ToUpperInvariant())
+                .Distinct()
+                .ToList();
+
+            return validCategories.Any() ? string.Join(", ", validCategories) : null;
+        }
+
+        private static string? FormatPractices(List<PracticeViewModel> practices)
+        {
+            if (practices == null || !practices.Any()) return null;
+
+            var parts = new List<string> { "РџСЂР°РєС‚РёРєРё:" };
+            foreach (var p in practices)
+            {
+                var period = $"{p.StartDate:MM.yyyy} вЂ“ {p.EndDate:MM.yyyy}";
+                parts.Add($"вЂў {p.Place} ({period}){(string.IsNullOrWhiteSpace(p.Description) ? "" : $" вЂ” {p.Description}")}");
+            }
+            return string.Join("\n", parts);
         }
     }
 }

--- a/WebReckrytingSystem/Pages/Admin/ResumeEdit.cshtml.cs
+++ b/WebReckrytingSystem/Pages/Admin/ResumeEdit.cshtml.cs
@@ -25,9 +25,13 @@ namespace WebReckrytingSystem.Pages.Admin
 
         public IReadOnlyList<string> Specialties { get; set; } = new List<string>();
         public IReadOnlyList<string> DriverLicenseCategories => DriverLicenseCategoryCatalog.All;
+        public string? SuccessMessage { get; set; }
+        public string? ErrorMessage { get; set; }
 
         public IActionResult OnGet(string email)
         {
+            SuccessMessage = TempData["SuccessMessage"]?.ToString();
+            ErrorMessage = TempData["ErrorMessage"]?.ToString();
             Specialties = _specialtyService.GetAllNames();
 
             var existingResume = _context.Resumes.FirstOrDefault(r => r.UserEmail == email);


### PR DESCRIPTION
### Motivation
- Админская страница редактирования резюме должна позволять править все поля резюме, как у соискателя, кроме учебного заведения.

### Description
- Заменена админская view `Pages/Admin/ResumeEdit.cshtml` на расширенную форму, скопированную и адаптированную из `Pages/Account/EditResume.cshtml`, с сохранением админского layout и навигации назад к списку резюме.
- Переведён backend страницы на использование `CreateResumeViewModel` в `Pages/Admin/ResumeEdit.cshtml.cs`, добавлены функции маппинга `MapResumeToViewModel`, `MapEducation`, `MapExperience`, `MapPractices` и форматирования полей при сохранении (навыки, практики, образование, водительские категории).
- Поле `EducationalInstitution` оставлено `readonly` в UI и дополнительно фиксируется на сервере перед валидацией/сохранением как `"ФГБОУ Колледж Росрезерва"`, чтобы предотвратить изменение даже при подмене запроса.
- Добавлена обработка скрытого поля навыков `SkillsHidden`, улучшена клиентская логика: теги навыков, управление практиками (добавление/удаление/реиндексация), кастомный dropdown для категорий прав и UI-стили в секциях `Styles`/`Scripts`.
- Изменён список изменённых файлов: `Pages/Admin/ResumeEdit.cshtml` и `Pages/Admin/ResumeEdit.cshtml.cs` (замена упрощённой админской формы на полную форму соискателя).

### Testing
- Попытка запустить `dotnet build WebReckrytingSystem/WebReckrytingSystem.sln` завершилась ошибкой в среде CI: `dotnet: command not found`, поэтому сборка/юнит-тесты не выполнялись.
- Были выполнены быстрая проверка изменений в файлах и проверка работоспособности сценария копирования/адаптации шаблона в локальном репозитории (файлы обновлены успешно).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f27c7c4748333a1cd697280951cf7)