### PR TITLE
Добавить `SuccessMessage`/`ErrorMessage` в `ResumeEditModel` (Admin)

### DIFF
--- a/WebReckrytingSystem/Pages/Admin/ResumeEdit.cshtml.cs
+++ b/WebReckrytingSystem/Pages/Admin/ResumeEdit.cshtml.cs
@@ -25,9 +25,13 @@ namespace WebReckrytingSystem.Pages.Admin
 
         public IReadOnlyList<string> Specialties { get; set; } = new List<string>();
         public IReadOnlyList<string> DriverLicenseCategories => DriverLicenseCategoryCatalog.All;
+        public string? SuccessMessage { get; set; }
+        public string? ErrorMessage { get; set; }
 
         public IActionResult OnGet(string email)
         {
+            SuccessMessage = TempData["SuccessMessage"]?.ToString();
+            ErrorMessage = TempData["ErrorMessage"]?.ToString();
             Specialties = _specialtyService.GetAllNames();
 
             var existingResume = _context.Resumes.FirstOrDefault(r => r.UserEmail == email);


### PR DESCRIPTION
### Motivation
- Исправить ошибку компиляции Razor-страницы, где `ResumeEdit.cshtml` обращается к `Model.SuccessMessage` и `Model.ErrorMessage`, но модель страницы их не предоставляет.

### Description
- Добавлены свойства `public string? SuccessMessage { get; set; }` и `public string? ErrorMessage { get; set; }` в `Pages/Admin/ResumeEdit.cshtml.cs`.
- Инициализация этих свойств выполнена в `OnGet` чтением значений из `TempData` через `TempData["SuccessMessage"]?.ToString()` и `TempData["ErrorMessage"]?.ToString()`.
- Изменения минимальны и направлены на восстановление привязки toast-сообщений в Razor-странице без изменения логики сохранения резюме.

### Testing
- Выполнялась попытка запустить `dotnet build` в репозитории, но команда завершилась с ошибкой окружения: `dotnet: command not found`, поэтому сборка/тесты не были выполнены здесь.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f9659c4708333bad52a51c5b38718)