### PR TITLE
Include all resume fields in downloaded PDF

### DIFF
--- a/WebReckrytingSystem/Pages/Admin/ResumeDetails.cshtml.cs
+++ b/WebReckrytingSystem/Pages/Admin/ResumeDetails.cshtml.cs
@@ -154,12 +154,16 @@ public class ResumeDetailsModel : PageModel
                 AddRow("Возраст:", resume.Age?.ToString() ?? "");
                 AddRow("Пол:", resume.Gender);
                 AddRow("Специальность:", resume.Specialty);
+                AddRow("Желаемая должность:", resume.DesiredPosition);
                 AddRow("Желаемая зарплата:", resume.SalaryExpectations.HasValue
                     ? $"{resume.SalaryExpectations.Value:N0} ₽"
                     : "не указана");
                 AddRow("Тип занятости:", resume.EmploymentType);
                 AddRow("График:", resume.WorkSchedule);
                 AddRow("Готовность к командировкам:", tripReadiness);
+                AddRow("Наличие автомобиля:", resume.HasCar ? "Да" : "Нет");
+                AddRow("Категория прав:", string.IsNullOrWhiteSpace(resume.DriverLicenseCategory) ? "не указана" : resume.DriverLicenseCategory);
+                AddRow("Статус публикации:", resume.IsPublished ? "Опубликовано" : "Не опубликовано");
                 AddRow("Статус поиска работы:", resume.SearchStatus);
             });
 


### PR DESCRIPTION
### Motivation
- Сделать так, чтобы скачиваемое PDF резюме содержало всю информацию из модели `Resume` (всё, кроме аватарки), потому что часть полей не попадала в секцию «Основная информация». 

### Description
- В `WebReckrytingSystem/Pages/Admin/ResumeDetails.cshtml.cs` добавлены строки для вывода `DesiredPosition`, `HasCar`, `DriverLicenseCategory` и `IsPublished` в таблицу «Основная информация», чтобы PDF содержал эти поля. 
- Существующие разделы `Опыт работы`, `Образование`, `Навыки` и `Практики` сохранены без изменений, а аватарка остаётся исключённой.

### Testing
- Попытка выполнить `dotnet build WebReckrytingSystem/WebReckrytingSystem.csproj` завершилась неудачей, так как в окружении отсутствует `dotnet` (`/bin/bash: dotnet: command not found`).
- Из-за ограничения окружения автоматические сборочные или юнит-тесты не запускались.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0fa833f34883338371bba1414389f0)