### PR TITLE
Добавить индикатор непрочитанных сообщений для страницы «Чаты»

### DIFF
--- a/WebReckrytingSystem/Pages/Account/Chat.cshtml.cs
+++ b/WebReckrytingSystem/Pages/Account/Chat.cshtml.cs
@@ -167,6 +167,20 @@ namespace WebReckrytingSystem.Pages.Account
             });
         }
 
+
+        public async Task<IActionResult> OnGetUnreadCountAsync()
+        {
+            var userEmail = User.FindFirstValue(ClaimTypes.Email);
+            if (string.IsNullOrWhiteSpace(userEmail))
+                return new JsonResult(new { unreadCount = 0 });
+
+            var unreadCount = await _context.ChatMessages
+                .Where(m => m.RecipientEmail == userEmail && !m.IsRead)
+                .CountAsync();
+
+            return new JsonResult(new { unreadCount });
+        }
+
         private async Task LoadDataAsync()
         {
             var allRelated = await _context.ChatMessages
@@ -227,6 +241,20 @@ namespace WebReckrytingSystem.Pages.Account
                 }
 
                 Messages = await query.OrderBy(m => m.SentAt).ToListAsync();
+
+                var unreadIncoming = Messages
+                    .Where(m => m.RecipientEmail == CurrentUserEmail && m.SenderEmail == Peer && !m.IsRead)
+                    .ToList();
+
+                if (unreadIncoming.Any())
+                {
+                    foreach (var message in unreadIncoming)
+                    {
+                        message.IsRead = true;
+                    }
+
+                    await _context.SaveChangesAsync();
+                }
             }
         }
 

--- a/WebReckrytingSystem/Pages/Shared/_Layout.cshtml
+++ b/WebReckrytingSystem/Pages/Shared/_Layout.cshtml
@@ -64,7 +64,12 @@
                                     <li><a class="dropdown-item" href="@(isEmployer ? "/Account/EmployerDashboard" : isAdmin ? "/Admin/Index" : "/Account/JobSeekerDashboard")"><i class="fas fa-tachometer-alt me-2"></i>Личный кабинет</a></li>
                                     <li><a class="dropdown-item" href="@(isEmployer ? "/Resume/Search" : "/Vacancy/Search")"><i class="fas fa-search me-2"></i>Поиск</a></li>
                                     <li><a class="dropdown-item" href="/Account/Notifications"><i class="fas fa-bell me-2"></i>Уведомления</a></li>
-                                    <li><a class="dropdown-item" href="/Account/Chat"><i class="fas fa-comment me-2"></i>Чаты</a></li>
+                                    <li>
+                                        <a class="dropdown-item d-flex align-items-center justify-content-between" href="/Account/Chat">
+                                            <span><i class="fas fa-comment me-2"></i>Чаты</span>
+                                            <span id="chatUnreadBadge" class="badge rounded-pill bg-danger ms-2 d-none">0</span>
+                                        </a>
+                                    </li>
                                     <li><a class="dropdown-item" href="/Account/Favorites"><i class="fas fa-star me-2"></i>Избранное</a></li>
                                     <li><hr class="dropdown-divider"></li>
                                     <li><a class="dropdown-item" href="/Account/Settings"><i class="fas fa-cog me-2"></i>Настройки</a></li>
@@ -149,6 +154,38 @@
     </div>
 
     @await RenderSectionAsync("Scripts", required: false)
+
+    <script>
+        (() => {
+            const badge = document.getElementById('chatUnreadBadge');
+            if (!badge) return;
+
+            const applyUnreadCount = (count) => {
+                if (count > 0) {
+                    badge.textContent = count > 99 ? '99+' : String(count);
+                    badge.classList.remove('d-none');
+                } else {
+                    badge.textContent = '0';
+                    badge.classList.add('d-none');
+                }
+            };
+
+            const refreshUnreadCount = async () => {
+                try {
+                    const response = await fetch('/Account/Chat?handler=UnreadCount', { headers: { 'X-Requested-With': 'XMLHttpRequest' } });
+                    if (!response.ok) return;
+
+                    const data = await response.json();
+                    applyUnreadCount(Number(data.unreadCount) || 0);
+                } catch (error) {
+                    console.error('Ошибка при получении количества непрочитанных сообщений:', error);
+                }
+            };
+
+            refreshUnreadCount();
+            setInterval(refreshUnreadCount, 10000);
+        })();
+    </script>
 
     <script>
         function showToast(message, type = 'success') {


### PR DESCRIPTION
### Motivation
- Подсвечивать в навигации пункт «Чаты» (красный кружок с числом) при наличии новых сообщений и убирать подсветку после того как сообщения в соответствующих чатах будут прочитаны.

### Description
- Добавлен GET‑handler `OnGetUnreadCountAsync` в `Pages/Account/Chat.cshtml.cs`, возвращающий число непрочитанных входящих сообщений для текущего пользователя (`RecipientEmail == userEmail && !IsRead`).
- При загрузке выбранного диалога входящие сообщения от текущего собеседника помечаются `IsRead = true` и изменения сохраняются в базе (`SaveChangesAsync`).
- В `Pages/Shared/_Layout.cshtml` добавлен элемент badge с `id="chatUnreadBadge"` рядом с пунктом «Чаты» для отображения счётчика.
- В layout добавлен небольшой JS‑скрипт, который опрашивает `'/Account/Chat?handler=UnreadCount'` каждые 10 секунд и показывает/скрывает badge, форматируя большие числа как `99+`.

### Testing
- Попытка выполнить `dotnet build WebReckrytingSystem/WebReckrytingSystem.sln` завершилась неуспехом, так как в окружении отсутствует `dotnet` (`/bin/bash: dotnet: command not found`).
- Больше автоматических тестов не запускалось в этом окружении.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0faead7f948333bf0b508edd80ab92)