### PR TITLE
Фикс уникальных просмотров вакансий и рабочий недельный график

### DIFF
--- a/WebReckrytingSystem/Pages/Account/JobSeekerDashboard.cshtml
+++ b/WebReckrytingSystem/Pages/Account/JobSeekerDashboard.cshtml
@@ -341,7 +341,7 @@
             data: {
                 labels: weekData.map(d => d.date),
                 datasets: [{
-                    label: 'Просмотры профиля',
+                    label: 'Просмотры вакансий',
                     data: weekData.map(d => d.views),
                     borderColor: '#667eea',
                     backgroundColor: 'rgba(102, 126, 234, 0.1)',

--- a/WebReckrytingSystem/Pages/Account/JobSeekerDashboard.cshtml.cs
+++ b/WebReckrytingSystem/Pages/Account/JobSeekerDashboard.cshtml.cs
@@ -112,26 +112,42 @@ namespace WebReckrytingSystem.Pages.Account
             try
             {
                 TotalApplications = _context.Set<JobApplication>().Count(a => a.StudentEmail == userEmail);
-                TotalVacancyViews = _context.Set<VacancyView>().Count(v => v.UserEmail == userEmail);
+                TotalVacancyViews = _context.Set<VacancyView>()
+                    .Where(v => v.UserEmail == userEmail)
+                    .Select(v => new { v.VacancyCompanyName, v.VacancyTitle })
+                    .Distinct()
+                    .Count();
                 SavedVacanciesCount = _context.SavedVacancies.Count(s => s.StudentEmail == userEmail);
 
-                // WeekData можно оставить для графика, но WeekViews больше не нужен
-                var weekAgo = DateTime.Now.AddDays(-7);
-                WeekData = _context.DailyAnalytics
-                    .Where(d => d.UserEmail == userEmail && d.Date >= weekAgo)
-                    .OrderBy(d => d.Date)
-                    .ToList();
+                var weekStart = DateTime.UtcNow.Date.AddDays(-6);
+                var applicationsByDay = _context.Set<JobApplication>()
+                    .Where(a => a.StudentEmail == userEmail && a.AppliedAt.Date >= weekStart)
+                    .AsEnumerable()
+                    .GroupBy(a => a.AppliedAt.Date)
+                    .ToDictionary(g => g.Key, g => g.Count());
 
-                if (!WeekData.Any())
-                {
-                    WeekData = Enumerable.Range(0, 7).Select(i => new DailyAnalytic
+                var savedByDay = _context.SavedVacancies
+                    .Where(s => s.StudentEmail == userEmail && s.SavedAt.Date >= weekStart)
+                    .AsEnumerable()
+                    .GroupBy(s => s.SavedAt.Date)
+                    .ToDictionary(g => g.Key, g => g.Count());
+
+                var viewsByDay = _context.Set<VacancyView>()
+                    .Where(v => v.UserEmail == userEmail && v.ViewedAt.Date >= weekStart)
+                    .AsEnumerable()
+                    .GroupBy(v => v.ViewedAt.Date)
+                    .ToDictionary(g => g.Key, g => g.Count());
+
+                WeekData = Enumerable.Range(0, 7)
+                    .Select(i => weekStart.AddDays(i))
+                    .Select(date => new DailyAnalytic
                     {
-                        Date = DateTime.Now.AddDays(-i).Date,
-                        ProfileViews = 0,
-                        ApplicationsSent = 0,
-                        SavedVacancies = 0
-                    }).Reverse().ToList();
-                }
+                        Date = date,
+                        ProfileViews = viewsByDay.TryGetValue(date, out var views) ? views : 0,
+                        ApplicationsSent = applicationsByDay.TryGetValue(date, out var applications) ? applications : 0,
+                        SavedVacancies = savedByDay.TryGetValue(date, out var saved) ? saved : 0
+                    })
+                    .ToList();
             }
             catch (Exception ex)
             {
@@ -219,15 +235,34 @@ namespace WebReckrytingSystem.Pages.Account
                 if (string.IsNullOrEmpty(userEmail))
                     return Unauthorized();
 
-                var weekAgo = DateTime.Now.AddDays(-7);
-                var data = _context.DailyAnalytics
-                    .Where(d => d.UserEmail == userEmail && d.Date >= weekAgo)
-                    .Select(d => new
+                var weekStart = DateTime.UtcNow.Date.AddDays(-6);
+
+                var applicationsByDay = _context.Set<JobApplication>()
+                    .Where(a => a.StudentEmail == userEmail && a.AppliedAt.Date >= weekStart)
+                    .AsEnumerable()
+                    .GroupBy(a => a.AppliedAt.Date)
+                    .ToDictionary(g => g.Key, g => g.Count());
+
+                var savedByDay = _context.SavedVacancies
+                    .Where(s => s.StudentEmail == userEmail && s.SavedAt.Date >= weekStart)
+                    .AsEnumerable()
+                    .GroupBy(s => s.SavedAt.Date)
+                    .ToDictionary(g => g.Key, g => g.Count());
+
+                var viewsByDay = _context.Set<VacancyView>()
+                    .Where(v => v.UserEmail == userEmail && v.ViewedAt.Date >= weekStart)
+                    .AsEnumerable()
+                    .GroupBy(v => v.ViewedAt.Date)
+                    .ToDictionary(g => g.Key, g => g.Count());
+
+                var data = Enumerable.Range(0, 7)
+                    .Select(i => weekStart.AddDays(i))
+                    .Select(date => new
                     {
-                        date = d.Date.ToString("dd.MM"),
-                        views = d.ProfileViews,
-                        applications = d.ApplicationsSent,
-                        saved = d.SavedVacancies
+                        date = date.ToString("dd.MM"),
+                        views = viewsByDay.TryGetValue(date, out var views) ? views : 0,
+                        applications = applicationsByDay.TryGetValue(date, out var applications) ? applications : 0,
+                        saved = savedByDay.TryGetValue(date, out var saved) ? saved : 0
                     })
                     .ToList();
 

--- a/WebReckrytingSystem/Pages/Vacancy/Details.cshtml.cs
+++ b/WebReckrytingSystem/Pages/Vacancy/Details.cshtml.cs
@@ -36,7 +36,7 @@ namespace WebReckrytingSystem.Pages.Vacancy
             {
                 var userEmail = User.FindFirstValue(ClaimTypes.Email);
 
-                if (User.IsInRole("job_seeker"))
+                if (User.IsInRole("job_seeker") && !string.IsNullOrWhiteSpace(userEmail))
                 {
                     IsSavedByCurrentStudent = await _context.SavedVacancies
                         .AnyAsync(s => s.StudentEmail == userEmail &&
@@ -49,6 +49,24 @@ namespace WebReckrytingSystem.Pages.Vacancy
                              (m.SenderEmail == Vacancy.AuthorEmail && m.RecipientEmail == userEmail)) &&
                             m.VacancyCompanyName == companyName &&
                             m.VacancyTitle == title);
+
+                    var alreadyViewed = await _context.VacancyViews
+                        .AnyAsync(v => v.UserEmail == userEmail &&
+                                       v.VacancyCompanyName == companyName &&
+                                       v.VacancyTitle == title);
+
+                    if (!alreadyViewed)
+                    {
+                        _context.VacancyViews.Add(new Models.VacancyView
+                        {
+                            UserEmail = userEmail,
+                            VacancyCompanyName = companyName,
+                            VacancyTitle = title,
+                            ViewedAt = DateTime.UtcNow
+                        });
+
+                        await _context.SaveChangesAsync();
+                    }
                 }
             }
 

--- a/WebReckrytingSystem/Program.cs
+++ b/WebReckrytingSystem/Program.cs
@@ -172,6 +172,7 @@ PRIMARY KEY (`id`)");
     EnsureColumnExists(connection, "resumes", "gender", "VARCHAR(20) NOT NULL DEFAULT ''");
     EnsureColumnExists(connection, "resumes", "has_car", "TINYINT(1) NOT NULL DEFAULT 0");
     EnsureColumnExists(connection, "resumes", "driver_license_category", "VARCHAR(20) NULL");
+    EnsureIndexExists(connection, "vacancy_views", "ux_vacancy_views_user_vacancy", "UNIQUE (`user_email`, `vacancy_company_name`, `vacancy_title`)");
 }
 
 static void EnsureTableExists(MySqlConnection connection, string tableName, string tableDefinition)
@@ -179,6 +180,22 @@ static void EnsureTableExists(MySqlConnection connection, string tableName, stri
     using var command = connection.CreateCommand();
     command.CommandText = $"CREATE TABLE IF NOT EXISTS `{tableName}` ({tableDefinition}) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;";
     command.ExecuteNonQuery();
+}
+
+static void EnsureIndexExists(MySqlConnection connection, string tableName, string indexName, string indexDefinition)
+{
+    using var existsCommand = connection.CreateCommand();
+    existsCommand.CommandText = @"SELECT COUNT(*) FROM information_schema.statistics WHERE table_schema = DATABASE() AND table_name = @tableName AND index_name = @indexName;";
+    existsCommand.Parameters.AddWithValue("@tableName", tableName);
+    existsCommand.Parameters.AddWithValue("@indexName", indexName);
+    var exists = Convert.ToInt32(existsCommand.ExecuteScalar()) > 0;
+
+    if (!exists)
+    {
+        using var addCommand = connection.CreateCommand();
+        addCommand.CommandText = $"ALTER TABLE `{tableName}` ADD CONSTRAINT `{indexName}` {indexDefinition};";
+        addCommand.ExecuteNonQuery();
+    }
 }
 
 static void EnsureColumnExists(MySqlConnection connection, string tableName, string columnName, string columnDefinition)


### PR DESCRIPTION
### Motivation
- Обеспечить корректный учёт просмотров вакансий — считать в статистике только уникальные просмотры по паре (пользователь, вакансия) и показывать пометку «просмотрена» в списке вакансий. 
- Сделать рабочей карточку статистики за неделю (`chart-card`) на основе реальных действий пользователя за последние 7 дней (просмотры вакансий, отклики, сохранения). 

### Description
- При открытии страницы вакансии в `Pages/Vacancy/Details.cshtml.cs` добавлена проверка и запись в `vacancy_views` только если для данного `user + vacancy` ещё нет записи, с сохранением через `_context.SaveChangesAsync()` при первом просмотре. 
- В `Pages/Account/JobSeekerDashboard.cshtml.cs` поле `TotalVacancyViews` теперь считает количество уникальных вакансий через `Distinct()` по `VacancyCompanyName`/`VacancyTitle`, а `WeekData` и `OnGetChartData` перестроены: данные за 7 дней собираются динамически из `JobApplication`, `SavedVacancy` и `VacancyView` (по датам последних 7 дней). 
- Подпись линии на графике в `Pages/Account/JobSeekerDashboard.cshtml` изменена на «Просмотры вакансий» для соответствия метрике. 
- В `Program.cs` добавлена функция `EnsureIndexExists` и автоматически создаётся уникальный индекс `ux_vacancy_views_user_vacancy` на таблице `vacancy_views(user_email, vacancy_company_name, vacancy_title)` для защиты от дубликатов на уровне БД. 

### Testing
- Попытка автоматической сборки `dotnet build WebReckrytingSystem/WebReckrytingSystem.sln` завершилась неудачей из‑за отсутствия `dotnet` в окружении (`dotnet: command not found`).
- Других автоматизированных тестов (юнит/интеграция) в среде не запускалось.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0fb4ef7a40833383957e3a88abf3aa)