### PR TITLE
Админ: добавить загрузку/обновление логотипа компании на странице редактирования

### DIFF
--- a/WebReckrytingSystem/Pages/Admin/Companies/Edit.cshtml
+++ b/WebReckrytingSystem/Pages/Admin/Companies/Edit.cshtml
@@ -10,7 +10,7 @@
         <h5 class="mb-0"><i class="fas fa-edit me-2"></i>Редактирование компании</h5>
     </div>
     <div class="card-body">
-        <form method="post">
+        <form method="post" enctype="multipart/form-data">
             <div asp-validation-summary="ModelOnly" class="alert alert-danger @(ViewData.ModelState.ErrorCount > 0 ? "" : "d-none")"></div>
 
             <div class="mb-3">
@@ -30,6 +30,19 @@
                 <span asp-validation-for="Company.Website" class="text-danger small"></span>
             </div>
 
+
+            <div class="mb-3">
+                <label class="form-label fw-bold">Логотип компании</label>
+                <div class="d-flex align-items-center gap-3 mb-2">
+                    <img src="@(Model.Company.LogoUrl ?? "/images/rabotodatel.jpg")"
+                         alt="Логотип @Model.Company.Name"
+                         class="img-thumbnail rounded-3"
+                         style="width: 96px; height: 96px; object-fit: cover;" />
+                    <div class="small text-muted">Оставьте поле пустым, чтобы сохранить текущий логотип.</div>
+                </div>
+                <input asp-for="LogoFile" type="file" accept="image/*" class="form-control" />
+                <span asp-validation-for="LogoFile" class="text-danger small"></span>
+            </div>
             <div class="mb-3 form-check">
                 <input asp-for="Company.Verified" class="form-check-input" />
                 <label asp-for="Company.Verified" class="form-check-label fw-bold">Верифицирована</label>

--- a/WebReckrytingSystem/Pages/Admin/Companies/Edit.cshtml.cs
+++ b/WebReckrytingSystem/Pages/Admin/Companies/Edit.cshtml.cs
@@ -1,4 +1,4 @@
-using Microsoft.AspNetCore.Authorization;
+﻿using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.EntityFrameworkCore;
@@ -10,14 +10,19 @@ namespace WebReckrytingSystem.Pages.Admin.Companies;
 public class EditModel : PageModel
 {
     private readonly ApplicationDbContext _context;
+    private readonly IWebHostEnvironment _webHostEnvironment;
 
-    public EditModel(ApplicationDbContext context)
+    public EditModel(ApplicationDbContext context, IWebHostEnvironment webHostEnvironment)
     {
         _context = context;
+        _webHostEnvironment = webHostEnvironment;
     }
 
     [BindProperty]
     public Company Company { get; set; } = new();
+
+    [BindProperty]
+    public IFormFile? LogoFile { get; set; }
 
     public async Task<IActionResult> OnGetAsync(string name)
     {
@@ -44,6 +49,27 @@ public class EditModel : PageModel
         companyFromDb.Description = Company.Description?.Trim();
         companyFromDb.Website = Company.Website?.Trim();
         companyFromDb.Verified = Company.Verified;
+
+        if (LogoFile is { Length: > 0 })
+        {
+            if (!LogoFile.ContentType.StartsWith("image/", StringComparison.OrdinalIgnoreCase))
+            {
+                ModelState.AddModelError(nameof(LogoFile), "Допускаются только изображения.");
+                return Page();
+            }
+
+            var uploadsFolder = Path.Combine(_webHostEnvironment.WebRootPath, "uploads", "company-logos");
+            Directory.CreateDirectory(uploadsFolder);
+
+            var extension = Path.GetExtension(LogoFile.FileName);
+            var uniqueFileName = $"{Guid.NewGuid():N}{extension}";
+            var filePath = Path.Combine(uploadsFolder, uniqueFileName);
+
+            await using var stream = System.IO.File.Create(filePath);
+            await LogoFile.CopyToAsync(stream);
+
+            companyFromDb.LogoUrl = $"/uploads/company-logos/{uniqueFileName}";
+        }
 
         await _context.SaveChangesAsync();
 


### PR DESCRIPTION
### Motivation
- Администратору нужно иметь возможность изменить аватар (логотип) компании прямо на странице редактирования компании.
- В карточках и деталях вакансии должен отображаться логотип компании, а не аватар администратора, поэтому нужно убедиться, что источник изображения — `Company.LogoUrl`.

### Description
- В `Pages/Admin/Companies/Edit.cshtml` форма переведена на `multipart/form-data`, добавлен предпросмотр текущего логотипа и поле загрузки файла `LogoFile` для выбора нового изображения.
- В `Pages/Admin/Companies/Edit.cshtml.cs` добавлен `IWebHostEnvironment` в конструктор и `IFormFile? LogoFile` в модель, выполнена валидация `image/*`, сохранение файла в `wwwroot/uploads/company-logos` и обновление `Company.LogoUrl` при успешной загрузке.
- Остальные места (карточки вакансий и страница деталей) уже используют `vacancy.Company?.LogoUrl` и не требовали изменений для отображения аватара компании.

### Testing
- Попытка запустить сборку проекта командой `dotnet build WebReckrytingSystem/WebReckrytingSystem.sln` была выполнена, но в окружении отсутствует `dotnet`, поэтому автоматическая сборка не прошла (`/bin/bash: line 1: dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10397c5f2c8333840623a42c54fd33)