### PR TITLE
Add company logo upload to admin Edit and Details pages

### DIFF
--- a/WebReckrytingSystem/Pages/Admin/Companies/Edit.cshtml
+++ b/WebReckrytingSystem/Pages/Admin/Companies/Edit.cshtml
@@ -10,12 +10,12 @@
         <h5 class="mb-0"><i class="fas fa-edit me-2"></i>Редактирование компании</h5>
     </div>
     <div class="card-body">
-        <form method="post">
+        <form method="post" enctype="multipart/form-data">
             <div asp-validation-summary="ModelOnly" class="alert alert-danger @(ViewData.ModelState.ErrorCount > 0 ? "" : "d-none")"></div>
 
             <div class="mb-3">
                 <label class="form-label fw-bold">Название</label>
-                <input asp-for="Company.Name" class="form-control" disabled />
+                <input asp-for="Company.Name" class="form-control" readonly />
             </div>
 
             <div class="mb-3">
@@ -30,6 +30,19 @@
                 <span asp-validation-for="Company.Website" class="text-danger small"></span>
             </div>
 
+
+            <div class="mb-3">
+                <label class="form-label fw-bold">Логотип компании</label>
+                <div class="d-flex align-items-center gap-3 mb-2">
+                    <img src="@(Model.Company.LogoUrl ?? "/images/rabotodatel.jpg")"
+                         alt="Логотип @Model.Company.Name"
+                         class="img-thumbnail rounded-3"
+                         style="width: 96px; height: 96px; object-fit: cover;" />
+                    <div class="small text-muted">Оставьте поле пустым, чтобы сохранить текущий логотип.</div>
+                </div>
+                <input asp-for="LogoFile" type="file" accept="image/*" class="form-control" />
+                <span asp-validation-for="LogoFile" class="text-danger small"></span>
+            </div>
             <div class="mb-3 form-check">
                 <input asp-for="Company.Verified" class="form-check-input" />
                 <label asp-for="Company.Verified" class="form-check-label fw-bold">Верифицирована</label>

--- a/WebReckrytingSystem/Pages/Admin/Companies/Edit.cshtml.cs
+++ b/WebReckrytingSystem/Pages/Admin/Companies/Edit.cshtml.cs
@@ -1,4 +1,4 @@
-using Microsoft.AspNetCore.Authorization;
+﻿using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.EntityFrameworkCore;
@@ -10,14 +10,19 @@ namespace WebReckrytingSystem.Pages.Admin.Companies;
 public class EditModel : PageModel
 {
     private readonly ApplicationDbContext _context;
+    private readonly IWebHostEnvironment _webHostEnvironment;
 
-    public EditModel(ApplicationDbContext context)
+    public EditModel(ApplicationDbContext context, IWebHostEnvironment webHostEnvironment)
     {
         _context = context;
+        _webHostEnvironment = webHostEnvironment;
     }
 
     [BindProperty]
     public Company Company { get; set; } = new();
+
+    [BindProperty]
+    public IFormFile? LogoFile { get; set; }
 
     public async Task<IActionResult> OnGetAsync(string name)
     {
@@ -31,19 +36,52 @@ public class EditModel : PageModel
         return Page();
     }
 
-    public async Task<IActionResult> OnPostAsync(string name)
+    public async Task<IActionResult> OnPostAsync(string? name)
     {
-        if (!ModelState.IsValid)
-            return Page();
+        var companyName = string.IsNullOrWhiteSpace(name) ? Company.Name : name;
+        if (string.IsNullOrWhiteSpace(companyName))
+            return NotFound();
 
-        var companyFromDb = await _context.Companies.FindAsync(name);
+        var companyFromDb = await _context.Companies.FindAsync(companyName);
         if (companyFromDb == null)
             return NotFound();
+
+        ModelState.Remove("Company.Name");
+        if (!ModelState.IsValid)
+        {
+            Company = companyFromDb;
+            return Page();
+        }
 
         // Название компании не меняем (Primary Key)
         companyFromDb.Description = Company.Description?.Trim();
         companyFromDb.Website = Company.Website?.Trim();
         companyFromDb.Verified = Company.Verified;
+
+        if (LogoFile is { Length: > 0 })
+        {
+            if (string.IsNullOrWhiteSpace(LogoFile.ContentType) || !LogoFile.ContentType.StartsWith("image/", StringComparison.OrdinalIgnoreCase))
+            {
+                ModelState.AddModelError(nameof(LogoFile), "Допускаются только изображения.");
+                return Page();
+            }
+
+            var uploadsFolder = Path.Combine(_webHostEnvironment.WebRootPath, "uploads", "company-logos");
+            Directory.CreateDirectory(uploadsFolder);
+
+            var extension = Path.GetExtension(LogoFile.FileName);
+            if (string.IsNullOrWhiteSpace(extension))
+            {
+                extension = ".png";
+            }
+            var uniqueFileName = $"{Guid.NewGuid():N}{extension}";
+            var filePath = Path.Combine(uploadsFolder, uniqueFileName);
+
+            await using var stream = System.IO.File.Create(filePath);
+            await LogoFile.CopyToAsync(stream);
+
+            companyFromDb.LogoUrl = $"/uploads/company-logos/{uniqueFileName}";
+        }
 
         await _context.SaveChangesAsync();
 

--- a/WebReckrytingSystem/Pages/Admin/CompanyDetails.cshtml.cs
+++ b/WebReckrytingSystem/Pages/Admin/CompanyDetails.cshtml.cs
@@ -1,4 +1,4 @@
-using Microsoft.AspNetCore.Authorization;
+﻿using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.EntityFrameworkCore;
@@ -55,7 +55,7 @@ public class CompanyDetailsModel : PageModel
             return RedirectToPage(new { name });
         }
 
-        if (!LogoFile.ContentType.StartsWith("image/", StringComparison.OrdinalIgnoreCase))
+        if (string.IsNullOrWhiteSpace(LogoFile.ContentType) || !LogoFile.ContentType.StartsWith("image/", StringComparison.OrdinalIgnoreCase))
         {
             TempData["ErrorMessage"] = "Допускаются только изображения.";
             return RedirectToPage(new { name });
@@ -67,6 +67,10 @@ public class CompanyDetailsModel : PageModel
             Directory.CreateDirectory(uploadsFolder);
 
             var extension = Path.GetExtension(LogoFile.FileName);
+            if (string.IsNullOrWhiteSpace(extension))
+            {
+                extension = ".png";
+            }
             var uniqueFileName = $"{Guid.NewGuid():N}{extension}";
             var filePath = Path.Combine(uploadsFolder, uniqueFileName);
 


### PR DESCRIPTION
### Motivation
- Enable administrators to change company logos from the admin UI and properly persist uploaded images to the site.
- Fix form submission for the company name field so it still posts when not editable and avoid model validation blocking updates.

### Description
- Updated `Edit.cshtml` to add `enctype="multipart/form-data"`, show current logo thumbnail, add a `file` input bound to `LogoFile`, and changed the company name input from `disabled` to `readonly` so its value posts with the form.
- Enhanced `EditModel` to accept `IWebHostEnvironment`, bind `IFormFile? LogoFile`, accept a nullable `name` parameter, remove `Company.Name` from `ModelState` so validation doesn't block updates, and preserve the company primary key while updating other fields.
- Implemented server-side image handling in `OnPostAsync` to validate `ContentType`, fallback to `.png` when the uploaded filename has no extension, create `wwwroot/uploads/company-logos`, save files with a GUID filename, and set `Company.LogoUrl` to the saved path.
- Tightened image validation and added the same extension-fallback logic in `CompanyDetailsModel` upload handler and strengthened the `ContentType` null-check.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10397c5f2c8333840623a42c54fd33)