### PR TITLE
Fix admin company logo upload crash on edit/details pages

### DIFF
--- a/WebReckrytingSystem/Pages/Admin/Companies/Edit.cshtml.cs
+++ b/WebReckrytingSystem/Pages/Admin/Companies/Edit.cshtml.cs
@@ -60,16 +60,15 @@ public class EditModel : PageModel
 
         if (LogoFile is { Length: > 0 })
         {
-
-            if (string.IsNullOrWhiteSpace(LogoFile.ContentType) || !LogoFile.ContentType.StartsWith("image/", StringComparison.OrdinalIgnoreCase))
-            if (!LogoFile.ContentType.StartsWith("image/", StringComparison.OrdinalIgnoreCase))
-
+            if (string.IsNullOrWhiteSpace(LogoFile.ContentType) ||
+                !LogoFile.ContentType.StartsWith("image/", StringComparison.OrdinalIgnoreCase))
             {
                 ModelState.AddModelError(nameof(LogoFile), "Допускаются только изображения.");
                 return Page();
             }
 
-            var uploadsFolder = Path.Combine(_webHostEnvironment.WebRootPath, "uploads", "company-logos");
+            var webRootPath = ResolveWebRootPath();
+            var uploadsFolder = Path.Combine(webRootPath, "uploads", "company-logos");
             Directory.CreateDirectory(uploadsFolder);
 
             var extension = Path.GetExtension(LogoFile.FileName);
@@ -90,5 +89,17 @@ public class EditModel : PageModel
 
         TempData["SuccessMessage"] = "Компания успешно обновлена.";
         return RedirectToPage("/Admin/Companies/Companies");
+    }
+
+    private string ResolveWebRootPath()
+    {
+        if (!string.IsNullOrWhiteSpace(_webHostEnvironment.WebRootPath))
+        {
+            return _webHostEnvironment.WebRootPath;
+        }
+
+        var fallback = Path.Combine(_webHostEnvironment.ContentRootPath, "wwwroot");
+        Directory.CreateDirectory(fallback);
+        return fallback;
     }
 }

--- a/WebReckrytingSystem/Pages/Admin/CompanyDetails.cshtml.cs
+++ b/WebReckrytingSystem/Pages/Admin/CompanyDetails.cshtml.cs
@@ -63,7 +63,8 @@ public class CompanyDetailsModel : PageModel
 
         try
         {
-            var uploadsFolder = Path.Combine(_webHostEnvironment.WebRootPath, "uploads", "company-logos");
+            var webRootPath = ResolveWebRootPath();
+            var uploadsFolder = Path.Combine(webRootPath, "uploads", "company-logos");
             Directory.CreateDirectory(uploadsFolder);
 
             var extension = Path.GetExtension(LogoFile.FileName);
@@ -90,5 +91,17 @@ public class CompanyDetailsModel : PageModel
         }
 
         return RedirectToPage(new { name });
+    }
+
+    private string ResolveWebRootPath()
+    {
+        if (!string.IsNullOrWhiteSpace(_webHostEnvironment.WebRootPath))
+        {
+            return _webHostEnvironment.WebRootPath;
+        }
+
+        var fallback = Path.Combine(_webHostEnvironment.ContentRootPath, "wwwroot");
+        Directory.CreateDirectory(fallback);
+        return fallback;
     }
 }


### PR DESCRIPTION
### Motivation
- Admin pages crashed when uploading/changing a company avatar because `_webHostEnvironment.WebRootPath` can be empty in some host configurations and there was a duplicated/fragile `if` validating `LogoFile.ContentType`, causing 5xx errors.

### Description
- Normalize `LogoFile.ContentType` validation by removing the duplicated/incorrect `if` in `Pages/Admin/Companies/Edit.cshtml.cs` and keeping a single correct check.
- Add a `ResolveWebRootPath()` helper in both `Pages/Admin/Companies/Edit.cshtml.cs` and `Pages/Admin/CompanyDetails.cshtml.cs` that returns `_webHostEnvironment.WebRootPath` or falls back to `Path.Combine(_webHostEnvironment.ContentRootPath, "wwwroot")` and ensures the directory exists.
- Use the resolved `webRootPath` to build the `uploads/company-logos` path and call `Directory.CreateDirectory` before creating the uploaded file, preserving assignment of `Company.LogoUrl` and saving changes.

### Testing
- Attempted to run `dotnet build` but the environment lacks the SDK so the build failed with `/bin/bash: dotnet: command not found`, therefore no build/run tests were executed.
- No automated tests ran successfully in this environment due to the missing `dotnet` runtime.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a103f1495188333b8fa97881ff985c6)