### PR TITLE
Improve company logo upload robustness and error handling; add WebRootPath fallback and logging

### DIFF
--- a/WebReckrytingSystem/Pages/Admin/Companies/Edit.cshtml.cs
+++ b/WebReckrytingSystem/Pages/Admin/Companies/Edit.cshtml.cs
@@ -11,11 +11,13 @@ public class EditModel : PageModel
 {
     private readonly ApplicationDbContext _context;
     private readonly IWebHostEnvironment _webHostEnvironment;
+    private readonly ILogger<EditModel> _logger;
 
-    public EditModel(ApplicationDbContext context, IWebHostEnvironment webHostEnvironment)
+    public EditModel(ApplicationDbContext context, IWebHostEnvironment webHostEnvironment, ILogger<EditModel> logger)
     {
         _context = context;
         _webHostEnvironment = webHostEnvironment;
+        _logger = logger;
     }
 
     [BindProperty]
@@ -60,35 +62,56 @@ public class EditModel : PageModel
 
         if (LogoFile is { Length: > 0 })
         {
-
-            if (string.IsNullOrWhiteSpace(LogoFile.ContentType) || !LogoFile.ContentType.StartsWith("image/", StringComparison.OrdinalIgnoreCase))
-            if (!LogoFile.ContentType.StartsWith("image/", StringComparison.OrdinalIgnoreCase))
-
+            if (string.IsNullOrWhiteSpace(LogoFile.ContentType) ||
+                !LogoFile.ContentType.StartsWith("image/", StringComparison.OrdinalIgnoreCase))
             {
                 ModelState.AddModelError(nameof(LogoFile), "Допускаются только изображения.");
                 return Page();
             }
 
-            var uploadsFolder = Path.Combine(_webHostEnvironment.WebRootPath, "uploads", "company-logos");
-            Directory.CreateDirectory(uploadsFolder);
-
-            var extension = Path.GetExtension(LogoFile.FileName);
-            if (string.IsNullOrWhiteSpace(extension))
+            try
             {
-                extension = ".png";
+                var webRootPath = ResolveWebRootPath();
+                var uploadsFolder = Path.Combine(webRootPath, "uploads", "company-logos");
+                Directory.CreateDirectory(uploadsFolder);
+
+                var extension = Path.GetExtension(LogoFile.FileName);
+                if (string.IsNullOrWhiteSpace(extension))
+                {
+                    extension = ".png";
+                }
+                var uniqueFileName = $"{Guid.NewGuid():N}{extension}";
+                var filePath = Path.Combine(uploadsFolder, uniqueFileName);
+
+                await using var stream = System.IO.File.Create(filePath);
+                await LogoFile.CopyToAsync(stream);
+
+                companyFromDb.LogoUrl = $"/uploads/company-logos/{uniqueFileName}";
             }
-            var uniqueFileName = $"{Guid.NewGuid():N}{extension}";
-            var filePath = Path.Combine(uploadsFolder, uniqueFileName);
-
-            await using var stream = System.IO.File.Create(filePath);
-            await LogoFile.CopyToAsync(stream);
-
-            companyFromDb.LogoUrl = $"/uploads/company-logos/{uniqueFileName}";
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Ошибка загрузки логотипа компании {CompanyName}", companyFromDb.Name);
+                ModelState.AddModelError(nameof(LogoFile), "Не удалось загрузить логотип. Попробуйте ещё раз.");
+                Company = companyFromDb;
+                return Page();
+            }
         }
 
         await _context.SaveChangesAsync();
 
         TempData["SuccessMessage"] = "Компания успешно обновлена.";
         return RedirectToPage("/Admin/Companies/Companies");
+    }
+
+    private string ResolveWebRootPath()
+    {
+        if (!string.IsNullOrWhiteSpace(_webHostEnvironment.WebRootPath))
+        {
+            return _webHostEnvironment.WebRootPath;
+        }
+
+        var fallback = Path.Combine(_webHostEnvironment.ContentRootPath, "wwwroot");
+        Directory.CreateDirectory(fallback);
+        return fallback;
     }
 }

--- a/WebReckrytingSystem/Pages/Admin/CompanyDetails.cshtml.cs
+++ b/WebReckrytingSystem/Pages/Admin/CompanyDetails.cshtml.cs
@@ -63,7 +63,8 @@ public class CompanyDetailsModel : PageModel
 
         try
         {
-            var uploadsFolder = Path.Combine(_webHostEnvironment.WebRootPath, "uploads", "company-logos");
+            var webRootPath = ResolveWebRootPath();
+            var uploadsFolder = Path.Combine(webRootPath, "uploads", "company-logos");
             Directory.CreateDirectory(uploadsFolder);
 
             var extension = Path.GetExtension(LogoFile.FileName);
@@ -90,5 +91,17 @@ public class CompanyDetailsModel : PageModel
         }
 
         return RedirectToPage(new { name });
+    }
+
+    private string ResolveWebRootPath()
+    {
+        if (!string.IsNullOrWhiteSpace(_webHostEnvironment.WebRootPath))
+        {
+            return _webHostEnvironment.WebRootPath;
+        }
+
+        var fallback = Path.Combine(_webHostEnvironment.ContentRootPath, "wwwroot");
+        Directory.CreateDirectory(fallback);
+        return fallback;
     }
 }


### PR DESCRIPTION
### Motivation
- Ensure logo uploads work when `IWebHostEnvironment.WebRootPath` is empty and make the upload flow more robust.
- Surface and log failures during file save to aid troubleshooting and provide user-facing error messages.
- Strengthen content-type validation and file handling to avoid invalid uploads and missing file extensions.

### Description
- Inject `ILogger<EditModel>` into `EditModel` and log exceptions when logo upload fails in the edit flow using `_logger.LogError(...)`.
- Add a `ResolveWebRootPath()` helper to both `Edit.cshtml.cs` and `CompanyDetails.cshtml.cs` to fallback to `ContentRootPath/wwwroot` and ensure the directory exists.
- Tighten content-type checks to handle null/empty `ContentType`, default file extension to `.png` when missing, generate a unique filename with `Guid`, save the file under `uploads/company-logos`, and update `LogoUrl` accordingly.
- Wrap the file save in a `try/catch` in `EditModel` to add a model error and return the page on failure, and preserve the existing `TempData` error reporting in `CompanyDetails`.

### Testing
- Ran `dotnet build` to validate the project compiles and the build succeeded.
- Executed the existing automated test suite via `dotnet test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a103f1495188333b8fa97881ff985c6)